### PR TITLE
feat: use user-requirement as root requirements

### DIFF
--- a/crates/rattler_installs_packages/src/lib.rs
+++ b/crates/rattler_installs_packages/src/lib.rs
@@ -31,7 +31,7 @@ pub use package_name::{NormalizedPackageName, PackageName, ParsePackageNameError
 pub use pep440::Version;
 pub use project_info::{ArtifactHashes, ArtifactInfo, DistInfoMetadata, Meta, ProjectInfo, Yanked};
 pub use requirement::{
-    marker, PackageRequirement, ParseExtra, PythonRequirement, Requirement, UserRequirement,
+    marker, PackageRequirement, ParseExtraInEnv, PythonRequirement, Requirement, UserRequirement,
 };
 pub use specifier::{CompareOp, Specifier, Specifiers};
 

--- a/crates/rattler_installs_packages/src/requirement.rs
+++ b/crates/rattler_installs_packages/src/requirement.rs
@@ -325,7 +325,6 @@ impl Deref for PackageRequirement {
 #[derive(Debug, Clone, PartialEq, Eq, DeserializeFromStr, SerializeDisplay)]
 pub struct UserRequirement(Requirement);
 
-
 impl UserRequirement {
     pub fn into_inner(self) -> Requirement {
         self.0
@@ -335,7 +334,6 @@ impl UserRequirement {
         &self.0
     }
 }
-
 
 impl Display for UserRequirement {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/rip_bin/src/main.rs
+++ b/crates/rip_bin/src/main.rs
@@ -7,12 +7,12 @@ use resolvo::{DefaultSolvableDisplay, DependencyProvider, Solver};
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 use url::Url;
 
+use rattler_installs_packages::Requirement;
 use rattler_installs_packages::{
     normalize_index_url,
     resolvo_pypi::{PypiDependencyProvider, PypiPackageName},
     UserRequirement,
 };
-use rattler_installs_packages::{Requirement};
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]

--- a/crates/rip_bin/src/main.rs
+++ b/crates/rip_bin/src/main.rs
@@ -7,8 +7,12 @@ use resolvo::{DefaultSolvableDisplay, DependencyProvider, Solver};
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 use url::Url;
 
-use rattler_installs_packages::{normalize_index_url, resolvo_pypi::{PypiDependencyProvider, PypiPackageName}, UserRequirement};
-use rattler_installs_packages::{PackageRequirement, Requirement};
+use rattler_installs_packages::{
+    normalize_index_url,
+    resolvo_pypi::{PypiDependencyProvider, PypiPackageName},
+    UserRequirement,
+};
+use rattler_installs_packages::{Requirement};
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]

--- a/crates/rip_bin/src/main.rs
+++ b/crates/rip_bin/src/main.rs
@@ -7,17 +7,14 @@ use resolvo::{DefaultSolvableDisplay, DependencyProvider, Solver};
 use tracing_subscriber::{fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 use url::Url;
 
-use rattler_installs_packages::{
-    normalize_index_url,
-    resolvo_pypi::{PypiDependencyProvider, PypiPackageName},
-};
+use rattler_installs_packages::{normalize_index_url, resolvo_pypi::{PypiDependencyProvider, PypiPackageName}, UserRequirement};
 use rattler_installs_packages::{PackageRequirement, Requirement};
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
 struct Args {
     #[clap(num_args=1.., required=true)]
-    specs: Vec<PackageRequirement>,
+    specs: Vec<UserRequirement>,
 
     /// Base URL of the Python Package Index (default https://pypi.org/simple). This should point
     /// to a repository compliant with PEP 503 (the simple repository API).
@@ -57,7 +54,7 @@ async fn actual_main() -> miette::Result<()> {
         specifiers,
         extras,
         ..
-    } in args.specs.iter().map(PackageRequirement::as_inner)
+    } in args.specs.iter().map(UserRequirement::as_inner)
     {
         let dependency_package_name = provider
             .pool()


### PR DESCRIPTION
Use the `UserRequirement` as root requirement, so that one can not use extra's in the env marker, which to my reasoning does not make sense as a root level requirement.