### PR TITLE
update all dependencies to get rid of dependabot warning 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anes"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
 name = "anstream"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,17 +154,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -364,17 +359,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "bitflags 1.3.2",
- "textwrap 0.11.0",
- "unicode-width",
-]
-
-[[package]]
-name = "clap"
 version = "4.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "824956d0dca8334758a5b7f7e50518d66ea319330cbceedcf76905c2f6ab30e3"
@@ -474,24 +458,24 @@ dependencies = [
 
 [[package]]
 name = "criterion"
-version = "0.3.6"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01d6de93b2b6c65e17c634a26653a29d107b3c98c607c765bf38d041531cd8f"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
 dependencies = [
- "atty",
+ "anes",
  "cast",
- "clap 2.34.0",
+ "ciborium",
+ "clap",
  "criterion-plot",
- "csv",
+ "is-terminal",
  "itertools 0.10.5",
- "lazy_static",
  "num-traits",
+ "once_cell",
  "oorandom",
  "plotters",
  "rayon",
  "regex",
  "serde",
- "serde_cbor",
  "serde_derive",
  "serde_json",
  "tinytemplate",
@@ -500,9 +484,9 @@ dependencies = [
 
 [[package]]
 name = "criterion-plot"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2673cc8207403546f45f5fd319a974b1e6983ad1a3ee7e6041650013be041876"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
 dependencies = [
  "cast",
  "itertools 0.10.5",
@@ -549,27 +533,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "csv"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626ae34994d3d8d668f4269922248239db4ae42d538b14c398b74a52208e8086"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -965,15 +928,6 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
@@ -1144,9 +1098,9 @@ dependencies = [
 name = "index"
 version = "0.1.0"
 dependencies = [
- "clap 4.4.5",
+ "clap",
  "dirs",
- "indexmap 2.0.0",
+ "indexmap 2.0.1",
  "indicatif",
  "miette",
  "rand",
@@ -1173,9 +1127,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+checksum = "ad227c3af19d4914570ad36d30409928b75967c298feb9ea1969db3a610bb14e"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
@@ -1206,9 +1160,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.32.0"
+version = "1.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e02c584f4595792d09509a94cdb92a3cef7592b1eb2d9877ee6f527062d0ea"
+checksum = "1aa511b2e298cd49b1856746f6bb73e17036bcd66b25f5e92cdcdbec9bd75686"
 dependencies = [
  "console",
  "lazy_static",
@@ -1240,7 +1194,7 @@ version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi",
  "rustix",
  "windows-sys 0.48.0",
 ]
@@ -1394,7 +1348,7 @@ dependencies = [
  "supports-hyperlinks",
  "supports-unicode",
  "terminal_size",
- "textwrap 0.15.2",
+ "textwrap",
  "thiserror",
  "unicode-width",
 ]
@@ -1479,7 +1433,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.3",
+ "hermit-abi",
  "libc",
 ]
 
@@ -1668,7 +1622,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.0",
+ "indexmap 2.0.1",
 ]
 
 [[package]]
@@ -1813,7 +1767,7 @@ dependencies = [
  "futures",
  "http",
  "http-cache-semantics",
- "indexmap 2.0.0",
+ "indexmap 2.0.1",
  "insta",
  "miette",
  "mime",
@@ -2010,10 +1964,10 @@ dependencies = [
 name = "rip_bin"
 version = "0.1.0"
 dependencies = [
- "clap 4.4.5",
+ "clap",
  "console",
  "dirs",
- "indexmap 2.0.0",
+ "indexmap 2.0.1",
  "indicatif",
  "itertools 0.11.0",
  "miette",
@@ -2176,16 +2130,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_cbor"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
-dependencies = [
- "half",
- "serde",
-]
-
-[[package]]
 name = "serde_derive"
 version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2229,7 +2173,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.0.0",
+ "indexmap 2.0.1",
  "serde",
  "serde_json",
  "serde_with_macros",
@@ -2429,15 +2373,6 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
-
-[[package]]
-name = "textwrap"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
@@ -2449,18 +2384,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.48"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
+checksum = "1177e8c6d7ede7afde3585fd2513e611227efd6481bd78d2e82ba1ce16557ed4"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.48"
+version = "1.0.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
+checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/index/Cargo.toml
+++ b/crates/index/Cargo.toml
@@ -18,7 +18,7 @@ rustls-tls = ['rattler_installs_packages/rustls-tls', 'rip_bin/rustls-tls']
 [dependencies]
 clap = { version = "4.4.5", features = ["derive"] }
 dirs = "5.0.1"
-indexmap = "2.0.0"
+indexmap = "2.0.1"
 indicatif = "0.17.7"
 miette = { version = "5.10.0", features = ["fancy"] }
 rand = "0.8.5"

--- a/crates/rattler_installs_packages/Cargo.toml
+++ b/crates/rattler_installs_packages/Cargo.toml
@@ -26,7 +26,7 @@ fs4 = "0.6.6"
 futures = "0.3.28"
 http = "0.2.9"
 http-cache-semantics = { version = "1.0.1", default-features = false, features = ["with_serde", "reqwest"] }
-indexmap = "2.0.0"
+indexmap = "2.0.1"
 miette = "5.10.0"
 mime = "0.3.17"
 once_cell = "1.18.0"
@@ -42,7 +42,7 @@ serde_json = "1.0.107"
 serde_with = "3.3.0"
 smallvec = { version = "1.11.1", features = ["const_generics", "const_new"] }
 tempfile = "3.8.0"
-thiserror = "1.0.48"
+thiserror = "1.0.49"
 tl = "0.7.7"
 tokio = { version = "1.32.0" }
 tokio-util = { version = "0.7.9", features = ["compat"] }
@@ -53,8 +53,8 @@ resolvo = { version = "0.1.0", optional = true }
 dirs = "5.0.1"
 
 [dev-dependencies]
-criterion = "0.3"
-insta = { version = "1.32.0", features = ["ron"] }
+criterion = "0.5"
+insta = { version = "1.33.0", features = ["ron"] }
 miette = { version = "5.10.0", features = ["fancy"] }
 once_cell = "1.18.0"
 tokio = { version = "1.32.0", features = ["rt", "macros", "rt-multi-thread"] }

--- a/crates/rip_bin/Cargo.toml
+++ b/crates/rip_bin/Cargo.toml
@@ -21,20 +21,20 @@ native-tls = ['rattler_installs_packages/native-tls']
 rustls-tls = ['rattler_installs_packages/rustls-tls']
 
 [dependencies]
-clap = { version = "4.3.23", features = ["derive"] }
+clap = { version = "4.4.5", features = ["derive"] }
 console = { version = "0.15.7", features = ["windows-console-colors"] }
 dirs = "5.0.1"
-indexmap = "2.0.0"
-indicatif = "0.17.6"
+indexmap = "2.0.1"
+indicatif = "0.17.7"
 itertools = "0.11.0"
 miette = { version = "5.10.0", features = ["fancy"] }
 rattler_installs_packages = { path = "../rattler_installs_packages", default-features = false, features = ["resolvo"] }
-tabwriter = { version = "1.2.1", features = ["ansi_formatting"] }
-tokio = { version = "1.29.1", features = ["rt", "macros", "rt-multi-thread"] }
+tabwriter = { version = "1.3.0", features = ["ansi_formatting"] }
+tokio = { version = "1.32.0", features = ["rt", "macros", "rt-multi-thread"] }
 tracing = "0.1.37"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-url = "2.4.0"
-rand = "0.8.4"
+url = "2.4.1"
+rand = "0.8.5"
 serde = "1.0.188"
 serde_json = "1.0.107"
 


### PR DESCRIPTION
There was a warning regarding a transient `atty` dependency.