### PR TITLE
feat: don't cache metadata cause we are storing it already

### DIFF
--- a/crates/rattler_installs_packages/src/package_database.rs
+++ b/crates/rattler_installs_packages/src/package_database.rs
@@ -215,7 +215,7 @@ impl PackageDb {
 
         let mut bytes = Vec::new();
         self.http
-            .request(url, Method::GET, HeaderMap::default(), CacheMode::Default)
+            .request(url, Method::GET, HeaderMap::default(), CacheMode::NoStore)
             .await?
             .into_body()
             .read_to_end(&mut bytes)


### PR DESCRIPTION
Don't cache the http as we also cache it in the file db.