### PR TITLE
fix: ignore invalid requirements

### DIFF
--- a/crates/rattler_installs_packages/src/core_metadata.rs
+++ b/crates/rattler_installs_packages/src/core_metadata.rs
@@ -27,7 +27,12 @@ impl TryFrom<&[u8]> for WheelCoreMetadata {
 
         let mut requires_dist = Vec::new();
         for req_str in parsed.take_all("Requires-Dist").into_iter() {
-            requires_dist.push(req_str.parse()?);
+            match req_str.parse() {
+                Err(e) => {
+                    tracing::error!("ignoring Requires-Dist: {req_str}, failed to parse: {e}")
+                }
+                Ok(req) => requires_dist.push(req),
+            }
         }
 
         let requires_python = match parsed.maybe_take("Requires-Python")? {


### PR DESCRIPTION
This ignores invalidly formatted requirements when parsing metadata. The same thing [happens in pip](https://github.com/pypa/pip/blob/2ba5acc8a4772ca1dc0d62a2dfe8967af28649d6/src/pip/_internal/resolution/resolvelib/factory.py#L392).

Fix #27 