### PR TITLE
fix: allow wildcards in ambiguos specifiers

### DIFF
--- a/crates/rattler_installs_packages/src/requirement.rs
+++ b/crates/rattler_installs_packages/src/requirement.rs
@@ -181,7 +181,7 @@ pub mod marker {
                             // be parsed as a wildcard with a wildcard-accepting op),
                             // then we do a version comparison
                             if let Ok(lhs_ver) = lhs_val.parse() {
-                                if let Ok(rhs_ranges) = op.ranges(rhs_val) {
+                                if let Ok(rhs_ranges) = op.ranges(rhs_val, true) {
                                     return Ok(rhs_ranges
                                         .into_iter()
                                         .any(|r| r.contains(&lhs_ver)));

--- a/crates/rattler_installs_packages/src/resolve.rs
+++ b/crates/rattler_installs_packages/src/resolve.rs
@@ -49,7 +49,7 @@ impl VersionSet for PypiVersionSet {
     type V = PypiVersion;
 
     fn contains(&self, v: &Self::V) -> bool {
-        match self.0.satisfied_by(&v.0) {
+        match self.0.satisfied_by(&v.0, true) {
             Err(e) => {
                 tracing::error!("failed to determine if '{}' contains '{}': {e}", &self.0, v);
                 false
@@ -205,7 +205,7 @@ impl<E: Env> DependencyProvider<PypiVersionSet, PypiPackageName> for PypiDepende
                         .parse()
                         .expect("invalid requires_python specifier");
                     if !python_specifier
-                        .satisfied_by(&self.python_version)
+                        .satisfied_by(&self.python_version, true)
                         .expect("failed to determine satisfiability of requires_python specifier")
                     {
                         artifacts.remove(idx);


### PR DESCRIPTION
Sometimes metadata contains specifiers like `>=3.5.*`. This is ambiguous because it either means `3.5.*` or `>=3.5`. The former is more restrictive than the latter but most likely one means the latter. This PR adds a boolean that allows a user to specify whether this should result in an error or whether the least restrictive bound should be chosen. With this PR the resolver chooses the least restrictive bound.

Fix #38 