### PR TITLE
fix: expose InstallOptions renamed as UnpackWheelOptions

### DIFF
--- a/crates/rattler_installs_packages/src/artifact.rs
+++ b/crates/rattler_installs_packages/src/artifact.rs
@@ -401,7 +401,7 @@ impl UnpackError {
 ///
 /// Not all options in this struct are relevant. Typically you will default a number of fields.
 #[derive(Default)]
-pub struct InstallOptions {
+pub struct UnpackWheelOptions {
     /// When specified an INSTALLER file is written to the dist-info folder of the package.
     pub installer: Option<String>,
 }
@@ -421,7 +421,7 @@ impl Wheel {
         &self,
         dest: &Path,
         paths: &InstallPaths,
-        options: &InstallOptions,
+        options: &UnpackWheelOptions,
     ) -> Result<(), UnpackError> {
         let vitals = self
             .get_vitals()
@@ -733,7 +733,7 @@ mod test {
             .unpack(
                 tmpdir.path(),
                 &install_paths,
-                &InstallOptions {
+                &UnpackWheelOptions {
                     installer: Some(String::from(INSTALLER)),
                 },
             )

--- a/crates/rattler_installs_packages/src/lib.rs
+++ b/crates/rattler_installs_packages/src/lib.rs
@@ -32,7 +32,7 @@ pub use resolve::{resolve, PinnedPackage};
 pub use file_store::{CacheKey, FileStore};
 pub use package_database::PackageDb;
 
-pub use artifact::{Artifact, InstallPaths, MetadataArtifact, Wheel};
+pub use artifact::{Artifact, InstallPaths, MetadataArtifact, UnpackWheelOptions, Wheel};
 pub use artifact_name::{
     ArtifactName, BuildTag, InnerAsArtifactName, ParseArtifactNameError, SDistFormat, SDistName,
     WheelName,

--- a/test-data/find_distributions/Lib/site-packages/zipp-3.17.0.dist-info/.gitkeep
+++ b/test-data/find_distributions/Lib/site-packages/zipp-3.17.0.dist-info/.gitkeep
@@ -1,0 +1,1 @@
+This file tests that this directory is not detected as a distribution.

--- a/test-data/find_distributions/Lib/site-packages/zipp/.gitkeep
+++ b/test-data/find_distributions/Lib/site-packages/zipp/.gitkeep
@@ -1,0 +1,1 @@
+This file tests that this directory is not detected as a distribution.


### PR DESCRIPTION
- Renames (and exposes) `InstallOptions` to `UnpackWheelOptions`.
- Fixes a bug where empty directories would be discovered as distributions.