### PR TITLE
feat: refactored name parsing from artifacts

### DIFF
--- a/crates/rattler_installs_packages/benches/html.rs
+++ b/crates/rattler_installs_packages/benches/html.rs
@@ -10,13 +10,13 @@ fn parse_project_info(c: &mut Criterion) {
                   <base href="https://example.com/new-base/">
                 </head>
                 <body>
-                  <a href="link1-1.0.tar.gz#sha256=0000000000000000000000000000000000000000000000000000000000000000">link1</a>
-                  <a href="/elsewhere/link2-2.0.zip" data-yanked="some reason">link2</a>
-                  <a href="link3-3.0.tar.gz" data-requires-python=">= 3.17">link3</a>
+                  <a href="link-1.0.tar.gz#sha256=0000000000000000000000000000000000000000000000000000000000000000">link1</a>
+                  <a href="/elsewhere/link-2.0.zip" data-yanked="some reason">link2</a>
+                  <a href="link-3.0.tar.gz" data-requires-python=">= 3.17">link3</a>
                 </body>
               </html>
             "#;
-    let url = Url::from_str("https://example.com/simple/").unwrap();
+    let url = Url::from_str("https://example.com/simple/link").unwrap();
     c.bench_with_input(
         BenchmarkId::new("parse_project_info", "html"),
         &(html, url),

--- a/crates/rattler_installs_packages/src/lib.rs
+++ b/crates/rattler_installs_packages/src/lib.rs
@@ -41,8 +41,8 @@ pub use package_database::PackageDb;
 
 pub use artifact::Artifact;
 pub use artifact_name::{
-    ArtifactName, BuildTag, InnerAsArtifactName, ParseArtifactNameError, SDistFormat, SDistName,
-    WheelName,
+    ArtifactName, BuildTag, InnerAsArtifactName, ParseArtifactNameError, SDistFilename,
+    SDistFormat, WheelFilename,
 };
 pub use distribution_finder::{find_distributions_in_venv, Distribution, FindDistributionError};
 pub use env_markers::Pep508EnvMakers;

--- a/crates/rattler_installs_packages/src/package_database.rs
+++ b/crates/rattler_installs_packages/src/package_database.rs
@@ -6,7 +6,7 @@ use crate::{
     html::{self, parse_project_info_html},
     http::{CacheMode, Http, HttpRequestError},
     project_info::{ArtifactInfo, ProjectInfo},
-    FileStore, NormalizedPackageName, Version, Wheel, WheelName,
+    FileStore, NormalizedPackageName, Version, Wheel, WheelFilename,
 };
 use async_http_range_reader::{AsyncHttpRangeReader, CheckSupportMethod};
 use elsa::sync::FrozenMap;
@@ -263,7 +263,7 @@ impl PackageDb {
         tracing::info!(url=%artifact_info.url, "lazy reading artifact");
 
         // Check if the artifact is the same type as the info.
-        let name = WheelName::try_as(&artifact_info.filename)
+        let name = WheelFilename::try_as(&artifact_info.filename)
             .expect("the specified artifact does not refer to type requested to read");
 
         if let Ok(mut reader) = AsyncHttpRangeReader::new(
@@ -295,7 +295,7 @@ impl PackageDb {
         artifact_info: &'a ArtifactInfo,
     ) -> miette::Result<(&'a ArtifactInfo, WheelCoreMetadata)> {
         // Check if the artifact is the same type as the info.
-        WheelName::try_as(&artifact_info.filename)
+        WheelFilename::try_as(&artifact_info.filename)
             .expect("the specified artifact does not refer to type requested to read");
 
         // Turn into PEP658 compliant URL

--- a/crates/rattler_installs_packages/src/venv.rs
+++ b/crates/rattler_installs_packages/src/venv.rs
@@ -136,7 +136,9 @@ impl VEnv {
 mod tests {
     use super::VEnv;
     use crate::venv::PythonLocation;
+    use crate::NormalizedPackageName;
     use std::path::Path;
+    use std::str::FromStr;
 
     #[test]
     pub fn venv_creation() {
@@ -149,6 +151,7 @@ mod tests {
         let wheel = crate::wheel::Wheel::from_path(
             &Path::new(env!("CARGO_MANIFEST_DIR"))
                 .join("../../test-data/wheels/wordle_python-2.3.32-py3-none-any.whl"),
+            &NormalizedPackageName::from_str("wordle_python").unwrap(),
         )
         .unwrap();
         venv.install_wheel(&wheel, &Default::default()).unwrap();


### PR DESCRIPTION
Now uses normalized or canonical package name to do the actual parsing.

Added some extra test to verify if this is working.