### PR TITLE
chore: add Borrow impl for Extra and NormalizedPackageName

### DIFF
--- a/crates/rattler_installs_packages/src/extra.rs
+++ b/crates/rattler_installs_packages/src/extra.rs
@@ -31,6 +31,7 @@
 use miette::Diagnostic;
 use serde::{Serialize, Serializer};
 use serde_with::DeserializeFromStr;
+use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 use std::str::FromStr;
@@ -108,5 +109,11 @@ impl Serialize for Extra {
         S: Serializer,
     {
         self.source.as_ref().serialize(serializer)
+    }
+}
+
+impl Borrow<str> for Extra {
+    fn borrow(&self) -> &str {
+        self.normalized.as_ref()
     }
 }

--- a/crates/rattler_installs_packages/src/package_name.rs
+++ b/crates/rattler_installs_packages/src/package_name.rs
@@ -2,6 +2,7 @@ use miette::Diagnostic;
 use regex::Regex;
 use serde::{Serialize, Serializer};
 use serde_with::{DeserializeFromStr, SerializeDisplay};
+use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
@@ -142,6 +143,12 @@ impl FromStr for NormalizedPackageName {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Ok(PackageName::from_str(s)?.into())
+    }
+}
+
+impl Borrow<str> for NormalizedPackageName {
+    fn borrow(&self) -> &str {
+        self.0.as_ref()
     }
 }
 


### PR DESCRIPTION
This allows these types to be used in HashMaps which can be queried by string.

I didnt implement it for `PackageName` because the hash of `PackageName` is not equal to the hash of `String`.