### PR TITLE
fix: ambigious import

### DIFF
--- a/crates/rattler_installs_packages/src/index/mod.rs
+++ b/crates/rattler_installs_packages/src/index/mod.rs
@@ -8,4 +8,4 @@ mod package_database;
 
 pub use package_database::PackageDb;
 
-pub use http::CacheMode;
+pub use self::http::CacheMode;


### PR DESCRIPTION
Fixes an issue with an ambiguous import:

```
error[E0659]: `http` is ambiguous
  --> C:\Users\User\.cargo\git\checkouts\rattler_installs_packages-3677d742e8596976\7de2c7a\crates\rattler_installs_packages\src\index\mod.rs:11:9
   |
11 | pub use http::CacheMode;
   |         ^^^^ ambiguous name
   |
   = note: ambiguous because of multiple potential import sources
   = note: `http` could refer to a crate passed with `--extern`
   = help: use `::http` to refer to this crate unambiguously
note: `http` could also refer to the module defined here
  --> C:\Users\User\.cargo\git\checkouts\rattler_installs_packages-3677d742e8596976\7de2c7a\crates\rattler_installs_packages\src\index\mod.rs:6:1
   |
6  | mod http;
   | ^^^^^^^^^
   = help: use `self::http` to refer to this module unambiguously
```