### PR TITLE
feat: we need wheel-builder to be public

### DIFF
--- a/crates/rattler_installs_packages/src/lib.rs
+++ b/crates/rattler_installs_packages/src/lib.rs
@@ -15,7 +15,7 @@ mod utils;
 
 pub mod resolve;
 
-mod wheel_builder;
+pub mod wheel_builder;
 
 mod win;
 


### PR DESCRIPTION
We need this to be public so that we can actually use it when installing wheels.