### PR TITLE
chore: prepare release

### DIFF
--- a/crates/rattler_installs_packages/Cargo.toml
+++ b/crates/rattler_installs_packages/Cargo.toml
@@ -10,7 +10,7 @@ repository.workspace = true
 license.workspace = true
 readme.workspace = true
 rust-version.workspace = true
-include = ["vendor/"]
+include = ["src/", "vendor/", "benches/"]
 
 [features]
 default = ["native-tls"]

--- a/crates/rip_bin/Cargo.toml
+++ b/crates/rip_bin/Cargo.toml
@@ -39,5 +39,4 @@ serde = "1.0.188"
 serde_json = "1.0.107"
 
 [package.metadata.release]
-# Dont publish the binary
 release = false

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -19,3 +19,6 @@ dirs = "5.0.1"
 fslock = "0.2.1"
 data-encoding = "2.4.0"
 tokio = "1.34.0"
+
+[package.metadata.release]
+release = false


### PR DESCRIPTION
This PR prepares the repository for release.

@tdejager 

Make sure you have `cargo-release` installed:

```shell
cargo install cargo-release
```

Then simply run the following from the root of the repository:

```shell
cargo release # verify that everything is as you expect it
cargo release --execute # actually publish the release
git push upstream v0.1.0 # push the tag to the upstream repository
```
