### PR TITLE
feat: create venv from rust

### DIFF
--- a/crates/rattler_installs_packages/Cargo.toml
+++ b/crates/rattler_installs_packages/Cargo.toml
@@ -57,7 +57,6 @@ tracing = { version = "0.1.37", default-features = false, features = ["attribute
 url = { version = "2.4.1", features = ["serde"] }
 zip = "0.6.6"
 resolvo = { version = "0.2.0", default-features = false }
-which = "4.4.2"
 pathdiff = "0.2.1"
 async_http_range_reader = "0.3.0"
 async_zip = { version = "0.0.15", features = ["tokio", "deflate"] }

--- a/crates/rattler_installs_packages/src/artifacts/wheel.rs
+++ b/crates/rattler_installs_packages/src/artifacts/wheel.rs
@@ -502,6 +502,15 @@ impl InstallPaths {
         &self.data
     }
 
+    /// Returns the location of the include directory
+    pub fn include(&self) -> PathBuf {
+        if self.windows {
+            PathBuf::from("Include")
+        } else {
+            PathBuf::from("include")
+        }
+    }
+
     /// Returns the location of the headers directory. The location of headers is specific to a
     /// distribution name.
     pub fn headers(&self, distribution_name: &str) -> PathBuf {

--- a/crates/rattler_installs_packages/src/python_env/system_python.rs
+++ b/crates/rattler_installs_packages/src/python_env/system_python.rs
@@ -1,4 +1,5 @@
 use itertools::Itertools;
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use thiserror::Error;
@@ -8,6 +9,8 @@ use thiserror::Error;
 pub enum FindPythonError {
     #[error("could not find python executable")]
     NotFound,
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
 }
 
 /// Try to find the python executable in the current environment.

--- a/crates/rattler_installs_packages/src/python_env/system_python.rs
+++ b/crates/rattler_installs_packages/src/python_env/system_python.rs
@@ -11,13 +11,28 @@ pub enum FindPythonError {
 }
 
 /// Try to find the python executable in the current environment.
+/// Using sys.executable aproach will return original interpretator path
+/// and not the shim in case of using which
 pub fn system_python_executable() -> Result<PathBuf, FindPythonError> {
     // When installed with homebrew on macOS, the python3 executable is called `python3` instead
     // Also on some ubuntu installs this is the case
     // For windows it should just be python
-    which::which("python3")
-        .or_else(|_| which::which("python"))
-        .map_err(|_| FindPythonError::NotFound)
+    let output = std::process::Command::new("python3")
+        .arg("-c")
+        .arg("import sys; print(sys.executable, end='')")
+        .output()
+        .or_else(|_| {
+            std::process::Command::new("python")
+                .arg("-c")
+                .arg("import sys; print(sys.executable, end='')")
+                .output()
+        })
+        .map_err(|_| FindPythonError::NotFound)?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let python_path = PathBuf::from_str(&stdout).map_err(|_| FindPythonError::NotFound)?;
+
+    Ok(python_path)
 }
 
 /// Errors that can occur while trying to parse the python version

--- a/crates/rattler_installs_packages/src/python_env/system_python.rs
+++ b/crates/rattler_installs_packages/src/python_env/system_python.rs
@@ -44,6 +44,7 @@ pub enum ParsePythonInterpreterVersionError {
     FindPythonError(#[from] FindPythonError),
 }
 
+#[derive(Clone)]
 pub struct PythonInterpreterVersion {
     pub major: u32,
     pub minor: u32,

--- a/crates/rattler_installs_packages/src/python_env/system_python.rs
+++ b/crates/rattler_installs_packages/src/python_env/system_python.rs
@@ -30,7 +30,12 @@ pub fn system_python_executable() -> Result<PathBuf, FindPythonError> {
         .map_err(|_| FindPythonError::NotFound)?;
 
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let python_path = PathBuf::from_str(&stdout).map_err(|_| FindPythonError::NotFound)?;
+    let python_path = PathBuf::from_str(&stdout).unwrap();
+
+    // sys.executable can return empty string or python's None
+    if !python_path.exists() {
+        return Err(FindPythonError::NotFound);
+    }
 
     Ok(python_path)
 }

--- a/crates/rattler_installs_packages/src/python_env/venv.rs
+++ b/crates/rattler_installs_packages/src/python_env/venv.rs
@@ -56,8 +56,6 @@ pub enum VEnvError {
     FindPythonError(#[from] FindPythonError),
     #[error(transparent)]
     ParsePythonInterpreterVersionError(#[from] ParsePythonInterpreterVersionError),
-    #[error("failed to run 'python -m venv': `{0}`")]
-    FailedToRun(String),
     #[error(transparent)]
     FailedToCreate(#[from] std::io::Error),
 }
@@ -159,10 +157,7 @@ impl VEnv {
 
         Self::setup_python(&abs_exe_path, &base_python_path, base_python_version)?;
 
-        Ok(Self {
-            location: venv_abs_dir.to_path_buf(),
-            install_paths,
-        })
+        Ok(VEnv::new(venv_abs_dir.to_path_buf(), install_paths))
     }
 
     /// Create all directories based on venv install paths mapping
@@ -348,7 +343,6 @@ mod tests {
         let venv_dir = tempfile::tempdir().unwrap();
 
         let venv = VEnv::create(venv_dir.path(), PythonLocation::System).unwrap();
-        let system_exec = crate::python_env::system_python_executable().unwrap();
 
         let base_prefix_output = venv
             .execute_command("import sys; print(sys.base_prefix, end='')")

--- a/crates/rattler_installs_packages/src/python_env/venv.rs
+++ b/crates/rattler_installs_packages/src/python_env/venv.rs
@@ -275,7 +275,7 @@ prompt = {}"#,
         {
             let base_exe_name = venv_exe_path
                 .file_name()
-                .expect("Cannot get windows venv exe name");
+                .expect("cannot get windows venv exe name");
             let python_bins = [
                 "python.exe",
                 "python_d.exe",
@@ -288,7 +288,7 @@ prompt = {}"#,
 
             let original_python_bin_dir = original_python_exe
                 .parent()
-                .expect("Cannot get system python parent folder");
+                .expect("cannot get system python parent folder");
             for bin_name in python_bins.into_iter() {
                 let original_python_bin = original_python_bin_dir.join(bin_name);
 

--- a/crates/rattler_installs_packages/src/python_env/venv.rs
+++ b/crates/rattler_installs_packages/src/python_env/venv.rs
@@ -25,7 +25,6 @@ pub fn copy_file<P: AsRef<Path>, U: AsRef<Path>>(from: P, to: U) -> std::io::Res
 #[cfg(windows)]
 pub fn copy_file<P: AsRef<Path>, U: AsRef<Path>>(from: P, to: U) -> std::io::Result<()> {
     fs::copy(from, to)?;
-    fs::set_permissions(to, fs::Permissions::from_mode(0o755)).unwrap();
     Ok(())
 }
 

--- a/crates/rattler_installs_packages/src/python_env/venv.rs
+++ b/crates/rattler_installs_packages/src/python_env/venv.rs
@@ -237,7 +237,7 @@ prompt = {}"#,
     pub fn setup_python(
         venv_exe_path: &Path,
         original_python_exe: &Path,
-        python_version: PythonInterpreterVersion,
+        #[cfg(not(windows))] python_version: PythonInterpreterVersion,
     ) -> std::io::Result<()> {
         if !venv_exe_path.exists() {
             copy_file(original_python_exe, venv_exe_path)?;

--- a/crates/rattler_installs_packages/src/python_env/venv.rs
+++ b/crates/rattler_installs_packages/src/python_env/venv.rs
@@ -152,11 +152,9 @@ impl VEnv {
         let install_paths = InstallPaths::for_venv(base_python_version.clone(), windows);
 
         Self::create_install_paths(venv_abs_dir, &install_paths)?;
-
         Self::create_pyvenv(venv_abs_dir, &base_python_path, base_python_version.clone())?;
 
         let exe_path = install_paths.scripts().join(base_python_name);
-
         let abs_exe_path = venv_abs_dir.join(exe_path);
 
         Self::setup_python(&abs_exe_path, &base_python_path, base_python_version)?;

--- a/crates/rattler_installs_packages/src/python_env/venv.rs
+++ b/crates/rattler_installs_packages/src/python_env/venv.rs
@@ -189,7 +189,7 @@ impl VEnv {
             }
         }
 
-        /// # https://bugs.python.org/issue21197
+        /// https://bugs.python.org/issue21197
         /// create lib64 as a symlink to lib on 64-bit non-OS X POSIX
         #[cfg(all(target_pointer_width = "64", unix, not(target_os = "macos")))]
         {
@@ -202,7 +202,7 @@ impl VEnv {
         Ok(())
     }
 
-    /// create pyvenv.cfg and write it's content based on system python
+    /// Create pyvenv.cfg and write it's content based on system python
     pub fn create_pyvenv(
         venv_path: &Path,
         python_path: &Path,
@@ -227,7 +227,10 @@ home = {}
 include-system-site-packages = false
 version = {}.{}.{}
 prompt = {}"#,
-            python_path.parent().unwrap().display(),
+            python_path
+                .parent()
+                .expect("system python path should have parent folder")
+                .display(),
             python_version.major,
             python_version.minor,
             python_version.patch,
@@ -239,7 +242,7 @@ prompt = {}"#,
         Ok(())
     }
 
-    /// copy original python executable and populate other suffixed binaries
+    /// Copy original python executable and populate other suffixed binaries
     pub fn setup_python(
         venv_exe_path: &Path,
         original_python_exe: &Path,
@@ -255,7 +258,9 @@ prompt = {}"#,
             &format!("python{}.{}", python_version.major, python_version.minor).to_string(),
         ];
 
-        let venv_bin = venv_exe_path.parent().unwrap();
+        let venv_bin = venv_exe_path
+            .parent()
+            .expect("venv exe binary should have parent folder");
 
         for bin_name in python_bins.into_iter() {
             let venv_python_bin = venv_bin.join(bin_name);
@@ -274,7 +279,7 @@ mod tests {
     use crate::python_env::PythonLocation;
     use crate::types::NormalizedPackageName;
     use std::env;
-    use std::path::{Path, PathBuf};
+    use std::path::Path;
     use std::str::FromStr;
 
     #[test]

--- a/crates/rattler_installs_packages/src/python_env/venv.rs
+++ b/crates/rattler_installs_packages/src/python_env/venv.rs
@@ -138,7 +138,6 @@ impl VEnv {
 
     /// Create a virtual environment at specified directory
     /// allows specifying if this is a windows venv
-    /// venv_dir is an absolute path
     pub fn create_custom(
         venv_abs_dir: &Path,
         python: PythonLocation,

--- a/crates/rattler_installs_packages/src/python_env/venv.rs
+++ b/crates/rattler_installs_packages/src/python_env/venv.rs
@@ -154,7 +154,15 @@ impl VEnv {
         let exe_path = install_paths.scripts().join(base_python_name);
         let abs_exe_path = venv_abs_dir.join(exe_path);
 
-        Self::setup_python(&abs_exe_path, &base_python_path, base_python_version)?;
+        #[cfg(not(windows))]
+        {
+            Self::setup_python(&abs_exe_path, &base_python_path, base_python_version)?;
+        }
+
+        #[cfg(windows)]
+        {
+            Self::setup_python(&abs_exe_path, &base_python_path)?;
+        }
 
         Ok(VEnv::new(venv_abs_dir.to_path_buf(), install_paths))
     }


### PR DESCRIPTION
Create python venv directly from rust.

Implementation based on built-in venv module.

I've changed a little `system_python_executable` implementation. `which` does not return original interpreter but a shim path when using pyenv. This does not work well when we later create `pyenv.cfg` and set `home =`



Closes: #83 