### PR TITLE
feat: move PythonInterpreterVersion to the public API

### DIFF
--- a/crates/rattler_installs_packages/src/python_env/mod.rs
+++ b/crates/rattler_installs_packages/src/python_env/mod.rs
@@ -19,9 +19,7 @@ pub use tags::{WheelTag, WheelTags};
 pub use byte_code_compiler::{ByteCodeCompiler, CompilationError, SpawnCompilerError};
 pub use distribution_finder::{find_distributions_in_venv, Distribution, FindDistributionError};
 pub use env_markers::Pep508EnvMakers;
-pub(crate) use system_python::{
-    system_python_executable, FindPythonError, ParsePythonInterpreterVersionError,
-    PythonInterpreterVersion,
-};
+pub(crate) use system_python::{system_python_executable, FindPythonError};
+pub use system_python::{ParsePythonInterpreterVersionError, PythonInterpreterVersion};
 pub use uninstall::{uninstall_distribution, UninstallDistributionError};
 pub use venv::{PythonLocation, VEnv, VEnvError};

--- a/crates/rattler_installs_packages/src/python_env/system_python.rs
+++ b/crates/rattler_installs_packages/src/python_env/system_python.rs
@@ -50,16 +50,26 @@ pub fn system_python_executable() -> Result<PathBuf, FindPythonError> {
 /// Errors that can occur while trying to parse the python version
 #[derive(Debug, Error)]
 pub enum ParsePythonInterpreterVersionError {
+    /// The version string is invalid.
     #[error("failed to parse version string, found '{0}' expect something like 'Python x.x.x'")]
     InvalidVersion(String),
+
+    /// The Python interpreter could not be found when attempting to determine its version.
     #[error(transparent)]
     FindPythonError(#[from] FindPythonError),
 }
 
+/// Represents a Python interpreters version parts.
 #[derive(Clone)]
 pub struct PythonInterpreterVersion {
+    /// The major version of the interpreter.
     pub major: u32,
+
+    /// The minor version of the interpreter.
     pub minor: u32,
+
+    /// The patch version of the interpreter.
+    /// Also known as the "micro" version from Python's `sys.version_info`.
     pub patch: u32,
 }
 
@@ -104,6 +114,7 @@ impl PythonInterpreterVersion {
         Ok(Self::new(major, minor, patch))
     }
 
+    /// Creates a PythonInterpreterVersion from its constituent parts.
     pub fn new(major: u32, minor: u32, patch: u32) -> Self {
         Self {
             major,


### PR DESCRIPTION
Moves `PythonInterpreterVersion` and its associated error enum in to the public API.

Closes #155 