### PR TITLE
feat: use python version in key for WheelCache

### DIFF
--- a/crates/rattler_installs_packages/src/artifacts/sdist.rs
+++ b/crates/rattler_installs_packages/src/artifacts/sdist.rs
@@ -267,7 +267,8 @@ mod tests {
             None,
             &resolve_options,
             HashMap::default(),
-        );
+        )
+        .unwrap();
 
         let result = wheel_builder.get_sdist_metadata(&sdist).await.unwrap();
 
@@ -290,7 +291,8 @@ mod tests {
             None,
             &resolve_options,
             HashMap::default(),
-        );
+        )
+        .unwrap();
 
         // Build the wheel
         wheel_builder.get_sdist_metadata(&sdist).await.unwrap();
@@ -315,7 +317,8 @@ mod tests {
             None,
             &resolve_options,
             HashMap::default(),
-        );
+        )
+        .unwrap();
 
         // Build the wheel
         let wheel = wheel_builder.build_wheel(&sdist).await.unwrap();
@@ -348,7 +351,8 @@ mod tests {
             None,
             &resolve_options,
             mandatory_env,
-        );
+        )
+        .unwrap();
 
         // Build the wheel
         let wheel = wheel_builder.build_wheel(&sdist).await.unwrap();
@@ -386,7 +390,8 @@ mod tests {
             None,
             &resolve_options,
             mandatory_env,
-        );
+        )
+        .unwrap();
 
         // Build the wheel
         let wheel = wheel_builder.build_wheel(&sdist).await.unwrap();
@@ -420,7 +425,8 @@ mod tests {
             None,
             &resolve_options,
             mandatory_env,
-        );
+        )
+        .unwrap();
 
         // Build the wheel
         let wheel = wheel_builder.build_wheel(&sdist).await;

--- a/crates/rattler_installs_packages/src/python_env/system_python.rs
+++ b/crates/rattler_installs_packages/src/python_env/system_python.rs
@@ -14,7 +14,7 @@ pub enum FindPythonError {
 }
 
 /// Try to find the python executable in the current environment.
-/// Using sys.executable aproach will return original interpretator path
+/// Using sys.executable approach will return original interpretation path
 /// and not the shim in case of using which
 pub fn system_python_executable() -> Result<PathBuf, FindPythonError> {
     // When installed with homebrew on macOS, the python3 executable is called `python3` instead
@@ -56,7 +56,7 @@ pub enum ParsePythonInterpreterVersionError {
     FindPythonError(#[from] FindPythonError),
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PythonInterpreterVersion {
     pub major: u32,
     pub minor: u32,

--- a/crates/rattler_installs_packages/src/python_env/venv.rs
+++ b/crates/rattler_installs_packages/src/python_env/venv.rs
@@ -36,6 +36,9 @@ pub enum PythonLocation {
     System,
     /// Use custom interpreter
     Custom(PathBuf),
+
+    /// Use custom interpreter with version
+    CustomWithVersion(PathBuf, PythonInterpreterVersion),
 }
 
 impl PythonLocation {
@@ -44,6 +47,16 @@ impl PythonLocation {
         match self {
             PythonLocation::System => system_python_executable(),
             PythonLocation::Custom(path) => Ok(path.clone()),
+            PythonLocation::CustomWithVersion(path, _) => Ok(path.clone()),
+        }
+    }
+
+    /// Get python version from executable
+    pub fn version(&self) -> Result<PythonInterpreterVersion, ParsePythonInterpreterVersionError> {
+        match self {
+            PythonLocation::System => PythonInterpreterVersion::from_system(),
+            PythonLocation::CustomWithVersion(_, version) => Ok(version.clone()),
+            PythonLocation::Custom(path) => PythonInterpreterVersion::from_path(path),
         }
     }
 }

--- a/crates/rattler_installs_packages/src/resolve/dependency_provider.rs
+++ b/crates/rattler_installs_packages/src/resolve/dependency_provider.rs
@@ -10,6 +10,7 @@ use crate::types::{
 use crate::wheel_builder::WheelBuilder;
 use elsa::FrozenMap;
 use itertools::Itertools;
+use miette::IntoDiagnostic;
 use pep440_rs::{Operator, Version, VersionSpecifier, VersionSpecifiers};
 use pep508_rs::{MarkerEnvironment, Requirement, VersionOrUrl};
 use resolvo::{
@@ -143,7 +144,8 @@ impl<'db, 'i> PypiDependencyProvider<'db, 'i> {
         env_variables: HashMap<String, String>,
     ) -> miette::Result<Self> {
         let wheel_builder =
-            WheelBuilder::new(package_db, markers, compatible_tags, options, env_variables);
+            WheelBuilder::new(package_db, markers, compatible_tags, options, env_variables)
+                .into_diagnostic()?;
 
         Ok(Self {
             pool: Pool::new(),

--- a/crates/rip_bin/src/main.rs
+++ b/crates/rip_bin/src/main.rs
@@ -227,7 +227,8 @@ async fn actual_main() -> miette::Result<()> {
             Some(&compatible_tags),
             &resolve_opts,
             Default::default(),
-        );
+        )
+        .into_diagnostic()?;
 
         for pinned_package in blueprint.into_iter().sorted_by(|a, b| a.name.cmp(&b.name)) {
             println!(


### PR DESCRIPTION
Building an architecture specific package depends on the python ABI (amongst other things)
probably, so will otherwise cause unwanted results.