### PR TITLE
misc: improve logging level of wheel build failures

### DIFF
--- a/crates/rattler_installs_packages/src/resolve/dependency_provider.rs
+++ b/crates/rattler_installs_packages/src/resolve/dependency_provider.rs
@@ -473,7 +473,7 @@ impl<'p> DependencyProvider<PypiVersionSet, PypiPackageName>
                 .unwrap()
         }) else {
             panic!(
-                "could not find metadata for any sdist or wheel for {} {}. The following artifacts are available:\n{}",
+                "could not find metadata for any sdist or wheel for {} {}. No metadata could be extracted for the following available artifacts:\n{}",
                 package_name, package_version, artifacts.iter().format_with("\n", |a, f| f(&format_args!("\t- {}", a.filename)))
             );
         };

--- a/crates/rattler_installs_packages/src/resolve/dependency_provider.rs
+++ b/crates/rattler_installs_packages/src/resolve/dependency_provider.rs
@@ -474,7 +474,7 @@ impl<'p> DependencyProvider<PypiVersionSet, PypiPackageName>
         }) else {
             panic!(
                 "could not find metadata for any sdist or wheel for {} {}. The following artifacts are available:\n{}",
-                package_name, package_version, artifacts.iter().format_with("\n", |a, f| f(&format_args!("- {}", a.filename)))
+                package_name, package_version, artifacts.iter().format_with("\n", |a, f| f(&format_args!("\t- {}", a.filename)))
             );
         };
 


### PR DESCRIPTION
I we find `metadata` for an artifact it does not really matter that the others have errored out I think. But if we *cannot* find any then we want to make this into an error, because currently the thread will panic after this happens.

This should also enable pixi users to see this error.