### PR TITLE
feat: cancel on metadata failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1861,18 +1861,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
+checksum = "0302c4a0442c456bd56f841aee5c3bfd17967563f6fadc9ceb9f9c23cf3807e0"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
+checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2161,7 +2161,7 @@ checksum = "b62dbe01f0b06f9d8dc7d49e05a0785f153b00b2c227856282f671e0318c9b15"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.4",
+ "regex-automata 0.4.5",
  "regex-syntax 0.8.2",
 ]
 
@@ -2176,9 +2176,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b7fa1134405e2ec9353fd416b17f8dacd46c473d7d3fd1cf202706a14eb792a"
+checksum = "5bb987efffd3c6d0d8f5f89510bb458559eab11e4f869acb20bf845e016259cd"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2267,7 +2267,7 @@ dependencies = [
 [[package]]
 name = "resolvo"
 version = "0.2.0"
-source = "git+https://github.com/mamba-org/resolvo.git?branch=main#7c1fa14852dde6b3936bcf67c1007815754ca2fc"
+source = "git+https://github.com/mamba-org/resolvo.git?branch=main#53a14d5203d67e1404e3a9f094366bfefe63f7fe"
 dependencies = [
  "bitvec",
  "elsa",

--- a/crates/rattler_installs_packages/src/resolve/solve.rs
+++ b/crates/rattler_installs_packages/src/resolve/solve.rs
@@ -315,8 +315,12 @@ pub async fn resolve<'db>(
                         .to_string()
                         .trim()
                 )),
-                UnsolvableOrCancelled::Cancelled(_) => {
-                    Err(miette::miette!("The resolution was cancelled"))
+                UnsolvableOrCancelled::Cancelled(e) => {
+                    Err(miette::miette!(
+                            help = "Probably an error during processing of source distributions. Please check the error message above.",
+                            "{}",
+                            e.downcast::<String>().expect("invalid cancellation error message, expected a string, this indicates an error in the code"
+                        )))
                 }
             }
         }

--- a/crates/rip_bin/src/main.rs
+++ b/crates/rip_bin/src/main.rs
@@ -214,16 +214,16 @@ async fn actual_main() -> miette::Result<()> {
     {
         Ok(blueprint) => blueprint,
         Err(err) => {
-            if args.json {
+            return if args.json {
                 let solution = Solution {
                     resolved: false,
                     packages: HashMap::default(),
                     error: Some(format!("{}", err)),
                 };
                 println!("{}", serde_json::to_string_pretty(&solution).unwrap());
-                return Ok(());
+                Ok(())
             } else {
-                miette::bail!("Could not solve for the requested requirements:\n{err}")
+                Err(err.wrap_err("Could not solve for requested requirements"))
             }
         }
     };


### PR DESCRIPTION
Cancel on failure to extract metadata instead of backtracking, should be more similar as to how pip does it. Does not continue to backtrack when this happens.

For example, `cargo r mamba-ssm` which fails to build for me results in:

```
2024-01-26T13:02:13.118203Z ERROR rattler_installs_packages::index::package_database: Error from source distributions 'mamba_ssm-1.1.1.tar.gz' skipped:
 could not build wheel: Traceback (most recent call last):
  File "/var/folders/fg/9x0q93cj3ls9nktfdlc_09080000gn/T/.tmpRfHc2U/build_frontend.py", line 124, in <module>
    get_requires_for_build_wheel(backend, work_dir)
  File "/var/folders/fg/9x0q93cj3ls9nktfdlc_09080000gn/T/.tmpRfHc2U/build_frontend.py", line 58, in get_requires_for_build_wheel
    result = f()
             ^^^
  File "/private/var/folders/fg/9x0q93cj3ls9nktfdlc_09080000gn/T/.tmpRfHc2U/venv/lib/python3.11/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
    return self._get_build_requires(config_settings, requirements=['wheel'])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/private/var/folders/fg/9x0q93cj3ls9nktfdlc_09080000gn/T/.tmpRfHc2U/venv/lib/python3.11/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
    self.run_setup()
  File "/private/var/folders/fg/9x0q93cj3ls9nktfdlc_09080000gn/T/.tmpRfHc2U/venv/lib/python3.11/site-packages/setuptools/build_meta.py", line 480, in run_setup
    super(_BuildMetaLegacyBackend, self).run_setup(setup_script=setup_script)
  File "/private/var/folders/fg/9x0q93cj3ls9nktfdlc_09080000gn/T/.tmpRfHc2U/venv/lib/python3.11/site-packages/setuptools/build_meta.py", line 311, in run_setup
    exec(code, locals())
  File "<string>", line 8, in <module>
ModuleNotFoundError: No module named 'packaging'

  × Could not solve for requested requirements
  ╰─▶ could not find metadata for any sdist or wheel for this package. No metadata could be extracted for the following available artifacts:
      	- mamba_ssm-1.1.1.tar.gz
  help: Probably an error during processing of source distributions. Please check the error message above.
  ```