### PR TITLE
feat: now uses miette error for the cancellation of resolvo

### DIFF
--- a/crates/rattler_installs_packages/src/index/package_database.rs
+++ b/crates/rattler_installs_packages/src/index/package_database.rs
@@ -265,7 +265,7 @@ impl PackageDb {
                 }
                 Err(err) => {
                     errors.push(format!(
-                        "Error from source distributions '{}' skipped: \n {}",
+                        "error while processing source distribution '{}': \n {}",
                         artifact_info.filename, err
                     ));
                     continue;
@@ -273,9 +273,10 @@ impl PackageDb {
             }
         }
 
-        // Could not find any metadata, so print the errors
-        for error in errors {
-            tracing::error!("{}", error);
+        // Check if errors is empty and if not return an error
+        if !errors.is_empty() {
+            tracing::warn!("errors while processing source distributions:");
+            miette::bail!("{}", errors.join("\n"));
         }
 
         Ok(None)

--- a/crates/rattler_installs_packages/src/resolve/solve.rs
+++ b/crates/rattler_installs_packages/src/resolve/solve.rs
@@ -317,13 +317,9 @@ pub async fn resolve<'db>(
                         .trim()
                 )),
                 UnsolvableOrCancelled::Cancelled(e) => {
-                    let e = e.downcast::<crate::resolve::dependency_provider::MetadataError>().expect("invalid cancellation error message, expected a string, this indicates an error in the code");
+                    let e = e.downcast::<crate::resolve::dependency_provider::MetadataError>().expect("invalid cancellation error message, expected a MetadataError, this indicates an error in the code");
                     let report = e.deref().clone().into();
                     Err(report)
-                    // Err(miette::miette!(
-                    //         help = "Probably an error during processing of source distributions. Please check the error message above.",
-                    //         "{}",
-                    //     )))
                 }
             };
         }

--- a/crates/rattler_installs_packages/src/resolve/solve.rs
+++ b/crates/rattler_installs_packages/src/resolve/solve.rs
@@ -10,6 +10,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 
 use std::collections::HashSet;
+use std::ops::Deref;
 
 /// Represents a single locked down distribution (python package) after calling [`resolve`].
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -316,13 +317,15 @@ pub async fn resolve<'db>(
                         .trim()
                 )),
                 UnsolvableOrCancelled::Cancelled(e) => {
-                    Err(miette::miette!(
-                            help = "Probably an error during processing of source distributions. Please check the error message above.",
-                            "{}",
-                            e.downcast::<String>().expect("invalid cancellation error message, expected a string, this indicates an error in the code"
-                        )))
+                    let e = e.downcast::<crate::resolve::dependency_provider::MetadataError>().expect("invalid cancellation error message, expected a string, this indicates an error in the code");
+                    let report = e.deref().clone().into();
+                    Err(report)
+                    // Err(miette::miette!(
+                    //         help = "Probably an error during processing of source distributions. Please check the error message above.",
+                    //         "{}",
+                    //     )))
                 }
-            }
+            };
         }
     };
 


### PR DESCRIPTION
Uses `miette` to use cancellation so that we can return an actual error. It's still a bit ugly because we need to convert to using our own error types everywhere, but I wanted a fix so that I get proper error reporting in pixi CI.