### PR TITLE
fix: use version and url in pinned package

### DIFF
--- a/crates/rattler_installs_packages/src/artifacts/sdist.rs
+++ b/crates/rattler_installs_packages/src/artifacts/sdist.rs
@@ -294,7 +294,7 @@ impl SourceArtifact for STree {
     }
 
     fn version(&self) -> PypiVersion {
-        PypiVersion::Url(self.name.version.clone())
+        PypiVersion::Url(self.name.url.clone())
     }
 
     fn artifact_name(&self) -> SourceArtifactName {

--- a/crates/rattler_installs_packages/src/artifacts/snapshots/rattler_installs_packages__artifacts__sdist__tests__build_rich_git_reference_source_code.snap
+++ b/crates/rattler_installs_packages/src/artifacts/snapshots/rattler_installs_packages__artifacts__sdist__tests__build_rich_git_reference_source_code.snap
@@ -8,7 +8,19 @@ STree(
             source: "rich",
             normalized: "rich",
         },
-        version: Url {
+        version: Version {
+            epoch: 0,
+            release: [
+                13,
+                7,
+                0,
+            ],
+            pre: None,
+            post: None,
+            dev: None,
+            local: None,
+        },
+        url: Url {
             scheme: "git+https",
             cannot_be_a_base: false,
             username: "",

--- a/crates/rattler_installs_packages/src/index/package_database.rs
+++ b/crates/rattler_installs_packages/src/index/package_database.rs
@@ -108,7 +108,10 @@ impl PackageDb {
             while let Some(response) = request_iter.next().await {
                 for artifact in response?.files {
                     result
-                        .entry(artifact.filename.version().clone())
+                        .entry(PypiVersion::Version {
+                            version: artifact.filename.version().clone(),
+                            package_allows_prerelease: artifact.filename.version().any_prerelease(),
+                        })
                         .or_default()
                         .push(artifact);
                 }
@@ -190,9 +193,13 @@ impl PackageDb {
             Some(path) => path,
         };
 
+        let dummy_version =
+            Version::from_str("0.0.0").expect("0.0.0 version should always be parseable");
+
         let stree_file_name = STreeFilename {
             distribution,
-            version: url.clone(),
+            version: dummy_version,
+            url: url.clone(),
         };
 
         let stree = STree {
@@ -207,7 +214,8 @@ impl PackageDb {
 
         let stree_file_name = STreeFilename {
             distribution: wheel_metadata.1.name.clone(),
-            version: url.clone(),
+            version: wheel_metadata.1.version.clone(),
+            url: url.clone(),
         };
 
         Ok((wheel_metadata, ArtifactName::STree(stree_file_name)))

--- a/crates/rattler_installs_packages/src/resolve/solve.rs
+++ b/crates/rattler_installs_packages/src/resolve/solve.rs
@@ -6,10 +6,12 @@ use crate::resolve::PypiVersion;
 use crate::types::PackageName;
 use crate::{types::ArtifactInfo, types::Extra, types::NormalizedPackageName};
 use elsa::FrozenMap;
+use pep440_rs::Version;
 use pep508_rs::{MarkerEnvironment, Requirement, VersionOrUrl};
 use resolvo::{DefaultSolvableDisplay, Pool, Solver, UnsolvableOrCancelled};
 use std::collections::HashMap;
 use std::str::FromStr;
+use url::Url;
 
 use std::collections::HashSet;
 use std::ops::Deref;
@@ -21,10 +23,10 @@ pub struct PinnedPackage<'db> {
     pub name: NormalizedPackageName,
 
     /// The selected version
-    pub version: PypiVersion,
+    pub version: Version,
 
     /// The possible direct URL for it
-    // pub url: Option<Url>,
+    pub url: Option<Url>,
 
     /// The extras that where selected either by the user or as part of the resolution.
     pub extras: HashSet<Extra>,
@@ -347,20 +349,32 @@ pub async fn resolve<'db>(
         let name = pool.resolve_package_name(solvable.name_id());
         let version = solvable.inner();
 
+        let artifacts: Vec<_> = provider
+            .cached_artifacts
+            .get(&solvable_id)
+            .into_iter()
+            .flatten()
+            .copied()
+            .collect();
+
+        let (version, url) = match version {
+            PypiVersion::Version { version, .. } => (version.clone(), None),
+            PypiVersion::Url(url) => {
+                // artifacts get by url have only one artifact and one possible version
+                let info = artifacts[0];
+                (info.filename.version(), Some(url.clone()))
+            }
+        };
+
         // Get the entry in the result
         let entry = result
             .entry(name.base().clone())
             .or_insert_with(|| PinnedPackage {
                 name: name.base().clone(),
-                version: version.clone(),
+                version,
+                url,
+                artifacts,
                 extras: Default::default(),
-                artifacts: provider
-                    .cached_artifacts
-                    .get(&solvable_id)
-                    .into_iter()
-                    .flatten()
-                    .copied()
-                    .collect(),
             });
 
         // Add the extra if selected

--- a/crates/rattler_installs_packages/src/types/artifact_name.rs
+++ b/crates/rattler_installs_packages/src/types/artifact_name.rs
@@ -1,6 +1,5 @@
 use super::{NormalizedPackageName, PackageName, ParsePackageNameError};
 use crate::python_env::WheelTag;
-use crate::resolve::PypiVersion;
 use crate::types::Version;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
@@ -41,17 +40,11 @@ pub enum ArtifactName {
 
 impl ArtifactName {
     /// Returns the version of the artifact
-    pub fn version(&self) -> PypiVersion {
+    pub fn version(&self) -> Version {
         match self {
-            ArtifactName::Wheel(name) => PypiVersion::Version {
-                version: name.version.clone(),
-                package_allows_prerelease: name.version.any_prerelease(),
-            },
-            ArtifactName::SDist(name) => PypiVersion::Version {
-                version: name.version.clone(),
-                package_allows_prerelease: name.version.any_prerelease(),
-            },
-            ArtifactName::STree(name) => PypiVersion::Url(name.version.clone()),
+            ArtifactName::Wheel(name) => name.version.clone(),
+            ArtifactName::SDist(name) => name.version.clone(),
+            ArtifactName::STree(name) => name.version.clone(),
         }
     }
 
@@ -202,8 +195,11 @@ pub struct STreeFilename {
     /// Distribution name, e.g. ‘django’, ‘pyramid’.
     pub distribution: PackageName,
 
+    /// Resolved version of source tree
+    pub version: Version,
+
     /// Direct reference
-    pub version: Url,
+    pub url: Url,
 }
 
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug, Hash, Serialize, Deserialize)]


### PR DESCRIPTION
This PR reverts the changes previous made for PinnedPackage
and will store 
`version: pep440_version`
and an `url: Optional<Url>` in case when pinnedpackage was provided by direct url
