### PR TITLE
bump: resolvo v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2276,8 +2276,9 @@ dependencies = [
 
 [[package]]
 name = "resolvo"
-version = "0.2.0"
-source = "git+https://github.com/mamba-org/resolvo.git?branch=main#53a14d5203d67e1404e3a9f094366bfefe63f7fe"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acd163bc7df01195423c83a7a391fecf319ff41d3de899694a9ccb698e790b29"
 dependencies = [
  "bitvec",
  "elsa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,3 @@ consolidate-commits = true
 tag-prefix = ""
 
 [patch.crates-io]
-#resolvo = { path="../resolvo" }
-resolvo = { git = "https://github.com/mamba-org/resolvo.git", branch = "main" }

--- a/crates/rattler_installs_packages/Cargo.toml
+++ b/crates/rattler_installs_packages/Cargo.toml
@@ -57,7 +57,7 @@ tokio-util = { version = "0.7.9", features = ["compat"] }
 tracing = { version = "0.1.37", default-features = false, features = ["attributes"] }
 url = { version = "2.4.1", features = ["serde"] }
 zip = "0.6.6"
-resolvo = { version = "0.2.0", default-features = false }
+resolvo = { version = "0.3.0", default-features = false }
 pathdiff = "0.2.1"
 async_zip = { version = "0.0.15", features = ["tokio", "deflate"] }
 tar = "0.4.40"


### PR DESCRIPTION
Removes the git dependency and just directly depend on release of resolvo.