### PR TITLE
refactor: remove all lifetimes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2273,8 +2273,9 @@ dependencies = [
 
 [[package]]
 name = "resolvo"
-version = "0.2.0"
-source = "git+https://github.com/mamba-org/resolvo.git?branch=main#53a14d5203d67e1404e3a9f094366bfefe63f7fe"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acd163bc7df01195423c83a7a391fecf319ff41d3de899694a9ccb698e790b29"
 dependencies = [
  "bitvec",
  "elsa",
@@ -3671,3 +3672,8 @@ dependencies = [
  "cc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "resolvo"
+version = "0.2.0"
+source = "git+https://github.com/mamba-org/resolvo.git?branch=main#53a14d5203d67e1404e3a9f094366bfefe63f7fe"

--- a/crates/rattler_installs_packages/Cargo.toml
+++ b/crates/rattler_installs_packages/Cargo.toml
@@ -57,7 +57,7 @@ tokio-util = { version = "0.7.9", features = ["compat"] }
 tracing = { version = "0.1.37", default-features = false, features = ["attributes"] }
 url = { version = "2.4.1", features = ["serde"] }
 zip = "0.6.6"
-resolvo = { version = "0.2.0", default-features = false }
+resolvo = { version = "0.3.0", default-features = false }
 pathdiff = "0.2.1"
 async_zip = { version = "0.0.15", features = ["tokio", "deflate"] }
 tar = "0.4.40"

--- a/crates/rattler_installs_packages/src/artifacts/sdist.rs
+++ b/crates/rattler_installs_packages/src/artifacts/sdist.rs
@@ -390,20 +390,23 @@ mod tests {
     use std::env;
     use std::path::Path;
     use std::str::FromStr;
+    use std::sync::Arc;
     use tempfile::TempDir;
     use url::Url;
 
-    fn get_package_db() -> (PackageDb, TempDir) {
+    fn get_package_db() -> (Arc<PackageDb>, TempDir) {
         let tempdir = tempfile::tempdir().unwrap();
         let client = ClientWithMiddleware::from(Client::new());
 
         (
-            PackageDb::new(
-                client,
-                &[url::Url::parse("https://pypi.org/simple/").unwrap()],
-                tempdir.path(),
-            )
-            .unwrap(),
+            Arc::new(
+                PackageDb::new(
+                    client,
+                    &[url::Url::parse("https://pypi.org/simple/").unwrap()],
+                    tempdir.path(),
+                )
+                .unwrap(),
+            ),
             tempdir,
         )
     }
@@ -450,13 +453,12 @@ mod tests {
         let sdist = SDist::from_path(&path, &"rich".parse().unwrap()).unwrap();
 
         let package_db = get_package_db();
-        let env_markers = Pep508EnvMakers::from_env().await.unwrap();
-        let resolve_options = ResolveOptions::default();
+        let env_markers = Arc::new(Pep508EnvMakers::from_env().await.unwrap().0);
         let wheel_builder = WheelBuilder::new(
-            &package_db.0,
-            &env_markers,
+            package_db.0,
+            env_markers,
             None,
-            &resolve_options,
+            ResolveOptions::default(),
             HashMap::default(),
         )
         .unwrap();
@@ -477,13 +479,12 @@ mod tests {
         let sdist = SDist::from_path(&path, &"rich".parse().unwrap()).unwrap();
 
         let package_db = get_package_db();
-        let env_markers = Pep508EnvMakers::from_env().await.unwrap();
-        let resolve_options = ResolveOptions::default();
+        let env_markers = Arc::new(Pep508EnvMakers::from_env().await.unwrap().0);
         let wheel_builder = WheelBuilder::new(
-            &package_db.0,
-            &env_markers,
+            package_db.0,
+            env_markers,
             None,
-            &resolve_options,
+            ResolveOptions::default(),
             HashMap::default(),
         )
         .unwrap();
@@ -503,13 +504,12 @@ mod tests {
         let sdist = SDist::from_path(&path, &"rich".parse().unwrap()).unwrap();
 
         let package_db = get_package_db();
-        let env_markers = Pep508EnvMakers::from_env().await.unwrap();
-        let resolve_options = ResolveOptions::default();
+        let env_markers = Arc::new(Pep508EnvMakers::from_env().await.unwrap().0);
         let wheel_builder = WheelBuilder::new(
-            &package_db.0,
-            &env_markers,
+            package_db.0,
+            env_markers,
             None,
-            &resolve_options,
+            ResolveOptions::default(),
             HashMap::default(),
         )
         .unwrap();
@@ -529,7 +529,7 @@ mod tests {
         let sdist = SDist::from_path(&path, &"env_package".parse().unwrap()).unwrap();
 
         let package_db = get_package_db();
-        let env_markers = Pep508EnvMakers::from_env().await.unwrap();
+        let env_markers = Arc::new(Pep508EnvMakers::from_env().await.unwrap().0);
         let resolve_options = ResolveOptions {
             ..Default::default()
         };
@@ -540,10 +540,10 @@ mod tests {
         mandatory_env.insert("MY_ENV_VAR".to_string(), "SOME_VALUE".to_string());
 
         let wheel_builder = WheelBuilder::new(
-            &package_db.0,
-            &env_markers,
+            package_db.0,
+            env_markers,
             None,
-            &resolve_options,
+            resolve_options,
             mandatory_env,
         )
         .unwrap();
@@ -567,7 +567,7 @@ mod tests {
         let sdist = SDist::from_path(&path, &"env_package".parse().unwrap()).unwrap();
 
         let package_db = get_package_db();
-        let env_markers = Pep508EnvMakers::from_env().await.unwrap();
+        let env_markers = Arc::new(Pep508EnvMakers::from_env().await.unwrap().0);
         let resolve_options = ResolveOptions {
             clean_env: true,
             ..Default::default()
@@ -579,10 +579,10 @@ mod tests {
         mandatory_env.insert(String::from("MY_ENV_VAR"), String::from("SOME_VALUE"));
 
         let wheel_builder = WheelBuilder::new(
-            &package_db.0,
-            &env_markers,
+            package_db.0,
+            env_markers,
             None,
-            &resolve_options,
+            resolve_options,
             mandatory_env,
         )
         .unwrap();
@@ -603,7 +603,7 @@ mod tests {
         let sdist = SDist::from_path(&path, &"env_package".parse().unwrap()).unwrap();
 
         let package_db = get_package_db();
-        let env_markers = Pep508EnvMakers::from_env().await.unwrap();
+        let env_markers = Arc::new(Pep508EnvMakers::from_env().await.unwrap().0);
         let resolve_options = ResolveOptions {
             clean_env: true,
             ..Default::default()
@@ -614,10 +614,10 @@ mod tests {
         let mandatory_env = HashMap::new();
 
         let wheel_builder = WheelBuilder::new(
-            &package_db.0,
-            &env_markers,
+            package_db.0,
+            env_markers,
             None,
-            &resolve_options,
+            resolve_options,
             mandatory_env,
         )
         .unwrap();
@@ -638,13 +638,12 @@ mod tests {
         let sdist = SDist::from_path(&path, &"filterpy".parse().unwrap()).unwrap();
 
         let package_db = get_package_db();
-        let env_markers = Pep508EnvMakers::from_env().await.unwrap();
-        let resolve_options = ResolveOptions::default();
+        let env_markers = Arc::new(Pep508EnvMakers::from_env().await.unwrap().0);
         let wheel_builder = WheelBuilder::new(
-            &package_db.0,
-            &env_markers,
+            package_db.0,
+            env_markers,
             None,
-            &resolve_options,
+            ResolveOptions::default(),
             HashMap::default(),
         );
 
@@ -703,17 +702,17 @@ mod tests {
         let sdist = SDist::from_path(&path, &"setuptools".parse().unwrap()).unwrap();
 
         let package_db = get_package_db();
-        let env_markers = Pep508EnvMakers::from_env().await.unwrap();
+        let env_markers = Arc::new(Pep508EnvMakers::from_env().await.unwrap().0);
         let resolve_options = ResolveOptions {
             sdist_resolution: SDistResolution::OnlySDists,
             ..Default::default()
         };
 
         let wheel_builder = WheelBuilder::new(
-            &package_db.0,
-            &env_markers,
+            package_db.0,
+            env_markers,
             None,
-            &resolve_options,
+            resolve_options,
             HashMap::default(),
         )
         .unwrap();
@@ -745,13 +744,12 @@ mod tests {
         let url = Url::from_file_path(path.canonicalize().unwrap()).unwrap();
 
         let package_db = get_package_db();
-        let env_markers = Pep508EnvMakers::from_env().await.unwrap();
-        let resolve_options = ResolveOptions::default();
+        let env_markers = Arc::new(Pep508EnvMakers::from_env().await.unwrap().0);
         let wheel_builder = WheelBuilder::new(
-            &package_db.0,
-            &env_markers,
+            package_db.0.clone(),
+            env_markers,
             None,
-            &resolve_options,
+            ResolveOptions::default(),
             HashMap::default(),
         )
         .unwrap();
@@ -775,13 +773,12 @@ mod tests {
         let url = Url::from_file_path(path.canonicalize().unwrap()).unwrap();
 
         let package_db = get_package_db();
-        let env_markers = Pep508EnvMakers::from_env().await.unwrap();
-        let resolve_options = ResolveOptions::default();
+        let env_markers = Arc::new(Pep508EnvMakers::from_env().await.unwrap().0);
         let wheel_builder = WheelBuilder::new(
-            &package_db.0,
-            &env_markers,
+            package_db.0.clone(),
+            env_markers,
             None,
-            &resolve_options,
+            ResolveOptions::default(),
             HashMap::default(),
         )
         .unwrap();
@@ -807,13 +804,12 @@ mod tests {
         // let sdist = SDist::from_path(&path, &"rich".parse().unwrap()).unwrap();
 
         let package_db = get_package_db();
-        let env_markers = Pep508EnvMakers::from_env().await.unwrap();
-        let resolve_options = ResolveOptions::default();
+        let env_markers = Arc::new(Pep508EnvMakers::from_env().await.unwrap().0);
         let wheel_builder = WheelBuilder::new(
-            &package_db.0,
-            &env_markers,
+            package_db.0.clone(),
+            env_markers,
             None,
-            &resolve_options,
+            ResolveOptions::default(),
             HashMap::default(),
         )
         .unwrap();
@@ -835,13 +831,12 @@ mod tests {
             Url::parse("https://github.com/Textualize/rich/archive/refs/tags/v13.7.0.zip").unwrap();
 
         let package_db = get_package_db();
-        let env_markers = Pep508EnvMakers::from_env().await.unwrap();
-        let resolve_options = ResolveOptions::default();
+        let env_markers = Arc::new(Pep508EnvMakers::from_env().await.unwrap().0);
         let wheel_builder = WheelBuilder::new(
-            &package_db.0,
-            &env_markers,
+            package_db.0.clone(),
+            env_markers,
             None,
-            &resolve_options,
+            ResolveOptions::default(),
             HashMap::default(),
         )
         .unwrap();
@@ -855,7 +850,7 @@ mod tests {
 
         let artifact_info = content
             .iter()
-            .flat_map(|(_, artifacts)| artifacts.iter())
+            .flat_map(|(_, artifacts)| artifacts.iter().cloned())
             .collect::<Vec<_>>();
 
         let wheel_metadata = package_db
@@ -876,13 +871,12 @@ mod tests {
         let url = Url::parse("git+https://github.com/Textualize/rich.git").unwrap();
 
         let package_db = get_package_db();
-        let env_markers = Pep508EnvMakers::from_env().await.unwrap();
-        let resolve_options = ResolveOptions::default();
+        let env_markers = Arc::new(Pep508EnvMakers::from_env().await.unwrap().0);
         let wheel_builder = WheelBuilder::new(
-            &package_db.0,
-            &env_markers,
+            package_db.0.clone(),
+            env_markers,
             None,
-            &resolve_options,
+            ResolveOptions::default(),
             HashMap::default(),
         )
         .unwrap();
@@ -904,13 +898,12 @@ mod tests {
         let url = Url::parse("git+https://github.com/Textualize/rich.git@v1.0.0").unwrap();
 
         let package_db = get_package_db();
-        let env_markers = Pep508EnvMakers::from_env().await.unwrap();
-        let resolve_options = ResolveOptions::default();
+        let env_markers = Arc::new(Pep508EnvMakers::from_env().await.unwrap().0);
         let wheel_builder = WheelBuilder::new(
-            &package_db.0,
-            &env_markers,
+            package_db.0.clone(),
+            env_markers,
             None,
-            &resolve_options,
+            ResolveOptions::default(),
             HashMap::default(),
         )
         .unwrap();
@@ -924,7 +917,7 @@ mod tests {
 
         let artifact_info = content
             .iter()
-            .flat_map(|(_, artifacts)| artifacts.iter())
+            .flat_map(|(_, artifacts)| artifacts.iter().cloned())
             .collect::<Vec<_>>();
 
         let wheel_metadata = package_db

--- a/crates/rattler_installs_packages/src/index/package_database.rs
+++ b/crates/rattler_installs_packages/src/index/package_database.rs
@@ -27,15 +27,19 @@ use parking_lot::Mutex;
 use rattler_digest::{compute_bytes_digest, Sha256};
 use reqwest::{header::CACHE_CONTROL, StatusCode};
 use reqwest_middleware::ClientWithMiddleware;
+use std::borrow::Borrow;
 use std::fs::File;
 use std::io::Seek;
 use std::path::PathBuf;
 use std::str::FromStr;
+use std::sync::Arc;
 use std::{fmt::Display, io::Read, path::Path};
 use tempfile::tempdir;
 use url::Url;
 
 use super::parse_hash;
+
+type VersionArtifacts = IndexMap<PypiVersion, Vec<Arc<ArtifactInfo>>>;
 
 /// Cache of the available packages, artifacts and their metadata.
 pub struct PackageDb {
@@ -48,7 +52,7 @@ pub struct PackageDb {
     metadata_cache: FileStore,
 
     /// A cache of package name to version to artifacts.
-    artifacts: FrozenMap<NormalizedPackageName, Box<IndexMap<PypiVersion, Vec<ArtifactInfo>>>>,
+    artifacts: FrozenMap<NormalizedPackageName, Box<VersionArtifacts>>,
 
     /// Cache to locally built wheels
     local_wheel_cache: WheelCache,
@@ -88,7 +92,7 @@ impl PackageDb {
     pub async fn available_artifacts<P: Into<NormalizedPackageName>>(
         &self,
         p: P,
-    ) -> miette::Result<&IndexMap<PypiVersion, Vec<ArtifactInfo>>> {
+    ) -> miette::Result<&IndexMap<PypiVersion, Vec<Arc<ArtifactInfo>>>> {
         let p = p.into();
         if let Some(cached) = self.artifacts.get(&p) {
             Ok(cached)
@@ -104,13 +108,13 @@ impl PackageDb {
             pin_mut!(request_iter);
 
             // Add all the incoming results to the set of results
-            let mut result: IndexMap<PypiVersion, Vec<ArtifactInfo>> = Default::default();
+            let mut result = IndexMap::default();
             while let Some(response) = request_iter.next().await {
                 for artifact in response?.files {
                     result
                         .entry(artifact.filename.version().clone())
-                        .or_default()
-                        .push(artifact);
+                        .or_insert_with(Vec::new)
+                        .push(Arc::new(artifact));
                 }
             }
 
@@ -128,11 +132,11 @@ impl PackageDb {
     }
 
     /// Return an sdist from file path
-    pub async fn get_sdist_from_file_path<'a, 'i>(
+    pub async fn get_sdist_from_file_path(
         &self,
         normalized_package_name: &NormalizedPackageName,
         path: &PathBuf,
-        wheel_builder: &WheelBuilder<'a, 'i>,
+        wheel_builder: &WheelBuilder,
     ) -> miette::Result<((Vec<u8>, WheelCoreMetadata), ArtifactName)> {
         let distribution = PackageName::from(normalized_package_name.clone());
 
@@ -177,12 +181,12 @@ impl PackageDb {
     }
 
     /// Return an stree from file path
-    pub async fn get_stree_from_file_path<'a, 'i>(
+    pub async fn get_stree_from_file_path(
         &self,
         normalized_package_name: &NormalizedPackageName,
         url: Url,
         path: Option<PathBuf>,
-        wheel_builder: &WheelBuilder<'a, 'i>,
+        wheel_builder: &WheelBuilder,
     ) -> miette::Result<((Vec<u8>, WheelCoreMetadata), ArtifactName)> {
         let distribution = PackageName::from(normalized_package_name.clone());
         let path = match path {
@@ -214,12 +218,12 @@ impl PackageDb {
     }
 
     /// Get artifact by file URL
-    pub async fn get_file_artifact<'a, 'i, P: Into<NormalizedPackageName>>(
+    pub async fn get_file_artifact<P: Into<NormalizedPackageName>>(
         &self,
         p: P,
         url: Url,
-        wheel_builder: &WheelBuilder<'a, 'i>,
-    ) -> miette::Result<&IndexMap<PypiVersion, Vec<ArtifactInfo>>> {
+        wheel_builder: &WheelBuilder,
+    ) -> miette::Result<&IndexMap<PypiVersion, Vec<Arc<ArtifactInfo>>>> {
         let path = if let Ok(path) = url.to_file_path() {
             path
         } else {
@@ -270,21 +274,17 @@ impl PackageDb {
             }
         };
 
-        let artifact_info = ArtifactInfo {
+        let artifact_info = Arc::new(ArtifactInfo {
             filename: artifact_name,
             url: url.clone(),
             hashes: Some(artifact_hash),
             requires_python: metadata.requires_python,
             dist_info_metadata: DistInfoMetadata::default(),
             yanked: Yanked::default(),
-        };
+        });
 
-        let mut result: IndexMap<PypiVersion, Vec<ArtifactInfo>> = Default::default();
-
-        result
-            .entry(PypiVersion::Url(url))
-            .or_default()
-            .push(artifact_info.clone());
+        let mut result = IndexMap::default();
+        result.insert(PypiVersion::Url(url.clone()), vec![artifact_info.clone()]);
 
         self.put_metadata_in_cache(&artifact_info, &metadata_bytes)
             .await?;
@@ -295,12 +295,12 @@ impl PackageDb {
     }
 
     /// Return an sdist from file path
-    pub async fn get_sdist_from_http<'a, 'i>(
+    pub async fn get_sdist_from_http(
         &self,
         normalized_package_name: &NormalizedPackageName,
         url: Url,
         bytes: Box<dyn ReadAndSeek + Send>,
-        wheel_builder: &WheelBuilder<'a, 'i>,
+        wheel_builder: &WheelBuilder,
     ) -> miette::Result<((Vec<u8>, WheelCoreMetadata), ArtifactName)> {
         // it's probably an sdist
         let distribution = PackageName::from(normalized_package_name.clone());
@@ -336,12 +336,12 @@ impl PackageDb {
     }
 
     /// Get artifact by file URL
-    pub async fn get_direct_http_url_artifact<'a, 'i, P: Into<NormalizedPackageName>>(
+    pub async fn get_direct_http_url_artifact<P: Into<NormalizedPackageName>>(
         &self,
         p: P,
         url: Url,
-        wheel_builder: &WheelBuilder<'a, 'i>,
-    ) -> miette::Result<&IndexMap<PypiVersion, Vec<ArtifactInfo>>> {
+        wheel_builder: &WheelBuilder,
+    ) -> miette::Result<&IndexMap<PypiVersion, Vec<Arc<ArtifactInfo>>>> {
         let str_name = url.path();
         let url_hash = url.fragment().and_then(parse_hash);
 
@@ -395,20 +395,17 @@ impl PackageDb {
             (filename, wheel_metadata.0, wheel_metadata.1)
         };
 
-        let artifact_info = ArtifactInfo {
+        let artifact_info = Arc::new(ArtifactInfo {
             filename,
             url: url.clone(),
             hashes: Some(artifact_hash),
             requires_python: metadata.requires_python,
             dist_info_metadata: DistInfoMetadata::default(),
             yanked: Yanked::default(),
-        };
+        });
 
-        let mut result: IndexMap<PypiVersion, Vec<ArtifactInfo>> = Default::default();
-        result
-            .entry(PypiVersion::Url(url))
-            .or_default()
-            .push(artifact_info.clone());
+        let mut result = IndexMap::default();
+        result.insert(PypiVersion::Url(url.clone()), vec![artifact_info.clone()]);
 
         self.put_metadata_in_cache(&artifact_info, &data_bytes)
             .await?;
@@ -419,12 +416,12 @@ impl PackageDb {
     }
 
     /// Get artifact by git reference
-    pub async fn get_git_artifact<'a, 'i, P: Into<NormalizedPackageName>>(
+    pub async fn get_git_artifact<P: Into<NormalizedPackageName>>(
         &self,
         p: P,
         url: Url,
-        wheel_builder: &WheelBuilder<'a, 'i>,
-    ) -> miette::Result<&IndexMap<PypiVersion, Vec<ArtifactInfo>>> {
+        wheel_builder: &WheelBuilder,
+    ) -> miette::Result<&IndexMap<PypiVersion, Vec<Arc<ArtifactInfo>>>> {
         let normalized_package_name = p.into();
 
         let parsed_url = ParsedUrl::new(&url)?;
@@ -474,20 +471,17 @@ impl PackageDb {
             sha256: Some(compute_bytes_digest::<Sha256>(url.as_str().as_bytes())),
         };
 
-        let artifact_info = ArtifactInfo {
+        let artifact_info = Arc::new(ArtifactInfo {
             filename,
             url: url.clone(),
             hashes: Some(project_hash),
             requires_python,
             dist_info_metadata,
             yanked,
-        };
+        });
 
-        let mut result: IndexMap<PypiVersion, Vec<ArtifactInfo>> = Default::default();
-        result
-            .entry(PypiVersion::Url(url))
-            .or_default()
-            .push(artifact_info.clone());
+        let mut result = IndexMap::default();
+        result.insert(PypiVersion::Url(url.clone()), vec![artifact_info.clone()]);
 
         self.put_metadata_in_cache(&artifact_info, &wheel_metadata.0)
             .await?;
@@ -498,13 +492,12 @@ impl PackageDb {
     }
 
     /// Get artifact directly from file, vcs, or url
-    pub async fn get_artifact_by_direct_url<'a, 'i, P: Into<NormalizedPackageName>>(
+    pub async fn get_artifact_by_direct_url<P: Into<NormalizedPackageName>>(
         &self,
         p: P,
         url: Url,
-        wheel_builder: &WheelBuilder<'a, 'i>,
-    ) -> miette::Result<&IndexMap<PypiVersion, Vec<ArtifactInfo>>> {
-        //conver to str
+        wheel_builder: &WheelBuilder,
+    ) -> miette::Result<&IndexMap<PypiVersion, Vec<Arc<ArtifactInfo>>>> {
         let p = p.into();
 
         if let Some(cached) = self.artifacts.get(&p) {
@@ -518,7 +511,7 @@ impl PackageDb {
             self.get_git_artifact(p, url, wheel_builder).await
         } else {
             Err(miette::miette!(
-                "Usage of unsecure protocol or unsupported scheme {:?}",
+                "Usage of insecure protocol or unsupported scheme {:?}",
                 url.scheme()
             ))
         }
@@ -548,14 +541,15 @@ impl PackageDb {
     /// Check if we already have one of the artifacts cached. Only do this if we have more than
     /// one artifact because otherwise, we'll do a request anyway if we dont have the file
     /// cached.
-    async fn metadata_for_cached_artifacts<'a>(
+    async fn metadata_for_cached_artifacts<'a, A: Borrow<ArtifactInfo>>(
         &self,
-        artifacts: &[&'a ArtifactInfo],
-    ) -> miette::Result<Option<(&'a ArtifactInfo, WheelCoreMetadata)>> {
-        for &artifact_info in artifacts.iter() {
-            if artifact_info.is::<Wheel>() {
+        artifacts: &'a [A],
+    ) -> miette::Result<Option<(&'a A, WheelCoreMetadata)>> {
+        for artifact_info in artifacts.iter() {
+            let artifact_info_ref = artifact_info.borrow();
+            if artifact_info_ref.is::<Wheel>() {
                 let result = self
-                    .get_artifact_with_cache::<Wheel>(artifact_info, CacheMode::OnlyIfCached)
+                    .get_artifact_with_cache::<Wheel>(artifact_info_ref, CacheMode::OnlyIfCached)
                     .await;
                 match result {
                     Ok(artifact) => {
@@ -564,13 +558,13 @@ impl PackageDb {
                         let metadata = artifact.metadata();
                         match metadata {
                             Ok((blob, metadata)) => {
-                                self.put_metadata_in_cache(artifact_info, &blob).await?;
+                                self.put_metadata_in_cache(artifact_info_ref, &blob).await?;
                                 return Ok(Some((artifact_info, metadata)));
                             }
                             Err(err) => {
                                 tracing::warn!(
                                     "Error reading metadata from artifact '{}' skipping ({:?})",
-                                    artifact_info.filename,
+                                    artifact_info_ref.filename,
                                     err
                                 );
                                 continue;
@@ -586,7 +580,7 @@ impl PackageDb {
             // We know that it is an sdist
             else {
                 let result = self
-                    .get_artifact_with_cache::<SDist>(artifact_info, CacheMode::OnlyIfCached)
+                    .get_artifact_with_cache::<SDist>(artifact_info_ref, CacheMode::OnlyIfCached)
                     .await;
 
                 match result {
@@ -594,7 +588,8 @@ impl PackageDb {
                         // Save the pep643 metadata in the cache if it is available
                         let metadata = sdist.pep643_metadata().into_diagnostic()?;
                         if let Some((bytes, _)) = metadata {
-                            self.put_metadata_in_cache(artifact_info, &bytes).await?;
+                            self.put_metadata_in_cache(artifact_info_ref, &bytes)
+                                .await?;
                         }
                     }
                     Err(err) => match err.downcast_ref::<HttpRequestError>() {
@@ -607,43 +602,44 @@ impl PackageDb {
         Ok(None)
     }
 
-    async fn get_metadata_wheels<'a>(
+    async fn get_metadata_wheels<'a, A: Borrow<ArtifactInfo>>(
         &self,
-        artifacts: &[&'a ArtifactInfo],
-    ) -> miette::Result<Option<(&'a ArtifactInfo, WheelCoreMetadata)>> {
+        artifacts: &'a [A],
+    ) -> miette::Result<Option<(&'a A, WheelCoreMetadata)>> {
         let wheels = artifacts
             .iter()
-            .copied()
-            .filter(|artifact_info| artifact_info.is::<Wheel>());
+            .filter(|artifact_info| (*artifact_info).borrow().is::<Wheel>());
 
         // Get the information from the first artifact. We assume the metadata is consistent across
         // all matching artifacts
         for artifact_info in wheels {
+            let ai = artifact_info.borrow();
+
             // Retrieve the metadata instead of the entire wheel
             // If the dist-info is available separately, we can use that instead
-            if artifact_info.dist_info_metadata.available {
+            if ai.dist_info_metadata.available {
                 return Ok(Some(self.get_pep658_metadata(artifact_info).await?));
             }
 
             // Try to load the data by sparsely reading the artifact (if supported)
-            if let Some(metadata) = self.get_lazy_metadata_wheel(artifact_info).await? {
+            if let Some(metadata) = self.get_lazy_metadata_wheel(ai).await? {
                 return Ok(Some((artifact_info, metadata)));
             }
 
             // Otherwise download the entire artifact
             let artifact = self
-                .get_artifact_with_cache::<Wheel>(artifact_info, CacheMode::Default)
+                .get_artifact_with_cache::<Wheel>(ai, CacheMode::Default)
                 .await?;
             let metadata = artifact.metadata();
             match metadata {
                 Ok((blob, metadata)) => {
-                    self.put_metadata_in_cache(artifact_info, &blob).await?;
+                    self.put_metadata_in_cache(ai, &blob).await?;
                     return Ok(Some((artifact_info, metadata)));
                 }
                 Err(err) => {
                     tracing::warn!(
                         "Error reading metadata from artifact '{}' skipping ({:?})",
-                        artifact_info.filename,
+                        ai.filename,
                         err
                     );
                     continue;
@@ -653,20 +649,20 @@ impl PackageDb {
         Ok(None)
     }
 
-    async fn get_metadata_sdists<'a, 'i>(
+    async fn get_metadata_sdists<'a, A: Borrow<ArtifactInfo>>(
         &self,
-        artifacts: &[&'a ArtifactInfo],
-        wheel_builder: &WheelBuilder<'a, 'i>,
-    ) -> miette::Result<Option<(&'a ArtifactInfo, WheelCoreMetadata)>> {
+        artifacts: &'a [A],
+        wheel_builder: &WheelBuilder,
+    ) -> miette::Result<Option<(&'a A, WheelCoreMetadata)>> {
         let sdists = artifacts
             .iter()
-            .copied()
-            .filter(|artifact_info| artifact_info.is::<SDist>());
+            .filter(|artifact_info| (*artifact_info).borrow().is::<SDist>());
 
         // Keep track of errors
         // only print these if we have not been able to find any metadata
         let mut errors = Vec::new();
-        for artifact_info in sdists {
+        for ai in sdists {
+            let artifact_info = ai.borrow();
             let artifact = self
                 .get_artifact_with_cache::<SDist>(artifact_info, CacheMode::Default)
                 .await?;
@@ -674,7 +670,7 @@ impl PackageDb {
             match metadata {
                 Ok((blob, metadata)) => {
                     self.put_metadata_in_cache(artifact_info, &blob).await?;
-                    return Ok(Some((artifact_info, metadata)));
+                    return Ok(Some((ai, metadata)));
                 }
                 Err(err) => {
                     errors.push(format!(
@@ -697,15 +693,15 @@ impl PackageDb {
 
     /// Returns the metadata from a set of artifacts. This function assumes that metadata is
     /// consistent for all artifacts of a single version.
-    pub async fn get_metadata<'a, 'i>(
+    pub async fn get_metadata<'a, A: Borrow<ArtifactInfo>>(
         &self,
-        artifacts: &[&'a ArtifactInfo],
-        wheel_builder: Option<&WheelBuilder<'a, 'i>>,
-    ) -> miette::Result<Option<(&'a ArtifactInfo, WheelCoreMetadata)>> {
+        artifacts: &'a [A],
+        wheel_builder: Option<&WheelBuilder>,
+    ) -> miette::Result<Option<(&'a A, WheelCoreMetadata)>> {
         // Check if we already have information about any of the artifacts cached.
         // Return if we do
-        for artifact_info in artifacts.iter().copied() {
-            if let Some(metadata_bytes) = self.metadata_from_cache(artifact_info).await {
+        for artifact_info in artifacts.iter() {
+            if let Some(metadata_bytes) = self.metadata_from_cache(artifact_info.borrow()).await {
                 return Ok(Some((
                     artifact_info,
                     WheelCoreMetadata::try_from(metadata_bytes.as_slice()).into_diagnostic()?,
@@ -777,16 +773,18 @@ impl PackageDb {
     /// Retrieve the PEP658 metadata for the given artifact.
     /// This assumes that the metadata is available in the repository
     /// This can be checked with the ArtifactInfo
-    async fn get_pep658_metadata<'a>(
+    async fn get_pep658_metadata<'a, A: Borrow<ArtifactInfo>>(
         &self,
-        artifact_info: &'a ArtifactInfo,
-    ) -> miette::Result<(&'a ArtifactInfo, WheelCoreMetadata)> {
+        artifact_info: &'a A,
+    ) -> miette::Result<(&'a A, WheelCoreMetadata)> {
+        let ai = artifact_info.borrow();
+
         // Check if the artifact is the same type as the info.
-        WheelFilename::try_as(&artifact_info.filename)
+        WheelFilename::try_as(&ai.filename)
             .expect("the specified artifact does not refer to type requested to read");
 
         // Turn into PEP658 compliant URL
-        let mut url = artifact_info.url.clone();
+        let mut url = ai.url.clone();
         url.set_path(&url.path().replace(".whl", ".whl.metadata"));
 
         let mut bytes = Vec::new();
@@ -799,7 +797,7 @@ impl PackageDb {
             .into_diagnostic()?;
 
         let metadata = WheelCoreMetadata::try_from(bytes.as_slice()).into_diagnostic()?;
-        self.put_metadata_in_cache(artifact_info, &bytes).await?;
+        self.put_metadata_in_cache(ai, &bytes).await?;
         Ok((artifact_info, metadata))
     }
 
@@ -864,10 +862,10 @@ impl PackageDb {
     /// Opens the specified artifact info. Downloads the artifact data from the remote location if
     /// the information is not already cached.
     #[async_recursion]
-    pub async fn get_wheel<'db, 'i>(
+    pub async fn get_wheel(
         &self,
         artifact_info: &ArtifactInfo,
-        builder: Option<&'async_recursion WheelBuilder<'db, 'i>>,
+        builder: Option<&'async_recursion WheelBuilder>,
     ) -> miette::Result<Wheel> {
         // Try to build the wheel for this SDist if possible
         if artifact_info.is::<SDist>() {
@@ -959,7 +957,7 @@ mod test {
         // Get the first wheel artifact
         let artifact_info = artifacts
             .iter()
-            .flat_map(|(_, artifacts)| artifacts.iter())
+            .flat_map(|(_, artifacts)| artifacts.into_iter().cloned())
             .collect::<Vec<_>>();
 
         let (_artifact, _metadata) = package_db

--- a/crates/rattler_installs_packages/src/resolve/dependency_provider.rs
+++ b/crates/rattler_installs_packages/src/resolve/dependency_provider.rs
@@ -22,10 +22,12 @@ use resolvo::{
 use serde::Deserialize;
 use serde::Serialize;
 use std::any::Any;
+use std::borrow::Borrow;
 use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 use std::str::FromStr;
+use std::sync::Arc;
 use thiserror::Error;
 use tokio::runtime::Handle;
 use tokio::task;
@@ -198,41 +200,48 @@ impl Display for PypiPackageName {
 }
 
 /// This is a [`DependencyProvider`] for PyPI packages
-pub(crate) struct PypiDependencyProvider<'db, 'i> {
+pub(crate) struct PypiDependencyProvider {
     pub pool: Pool<PypiVersionSet, PypiPackageName>,
-    package_db: &'db PackageDb,
-    wheel_builder: WheelBuilder<'db, 'i>,
-    markers: &'i MarkerEnvironment,
-    compatible_tags: Option<&'i WheelTags>,
+    package_db: Arc<PackageDb>,
+    wheel_builder: Arc<WheelBuilder>,
+    markers: Arc<MarkerEnvironment>,
+    compatible_tags: Option<Arc<WheelTags>>,
 
-    pub cached_artifacts: FrozenMap<SolvableId, Vec<&'db ArtifactInfo>>,
+    pub cached_artifacts: FrozenMap<SolvableId, Vec<Arc<ArtifactInfo>>>,
 
-    favored_packages: HashMap<NormalizedPackageName, PinnedPackage<'db>>,
-    locked_packages: HashMap<NormalizedPackageName, PinnedPackage<'db>>,
+    favored_packages: HashMap<NormalizedPackageName, PinnedPackage>,
+    locked_packages: HashMap<NormalizedPackageName, PinnedPackage>,
     pub name_to_url: FrozenMap<NormalizedPackageName, String>,
 
-    options: &'i ResolveOptions,
+    options: ResolveOptions,
     should_cancel_with_value: Mutex<Option<MetadataError>>,
 }
 
-impl<'db, 'i> PypiDependencyProvider<'db, 'i> {
+impl PypiDependencyProvider {
     /// Creates a new PypiDependencyProvider
     /// for use with the [`resolvo`] crate
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         pool: Pool<PypiVersionSet, PypiPackageName>,
-        package_db: &'db PackageDb,
-        markers: &'i MarkerEnvironment,
-        compatible_tags: Option<&'i WheelTags>,
-        locked_packages: HashMap<NormalizedPackageName, PinnedPackage<'db>>,
-        favored_packages: HashMap<NormalizedPackageName, PinnedPackage<'db>>,
+        package_db: Arc<PackageDb>,
+        markers: Arc<MarkerEnvironment>,
+        compatible_tags: Option<Arc<WheelTags>>,
+        locked_packages: HashMap<NormalizedPackageName, PinnedPackage>,
+        favored_packages: HashMap<NormalizedPackageName, PinnedPackage>,
         name_to_url: FrozenMap<NormalizedPackageName, String>,
-        options: &'i ResolveOptions,
+        options: ResolveOptions,
         env_variables: HashMap<String, String>,
     ) -> miette::Result<Self> {
-        let wheel_builder =
-            WheelBuilder::new(package_db, markers, compatible_tags, options, env_variables)
-                .into_diagnostic()?;
+        let wheel_builder = Arc::new(
+            WheelBuilder::new(
+                package_db.clone(),
+                markers.clone(),
+                compatible_tags.clone(),
+                options.clone(),
+                env_variables,
+            )
+            .into_diagnostic()?,
+        );
 
         Ok(Self {
             pool,
@@ -249,10 +258,10 @@ impl<'db, 'i> PypiDependencyProvider<'db, 'i> {
         })
     }
 
-    fn filter_candidates<'a>(
+    fn filter_candidates<'a, A: Borrow<ArtifactInfo>>(
         &self,
-        artifacts: &'a [ArtifactInfo],
-    ) -> Result<Vec<&'a ArtifactInfo>, &'static str> {
+        artifacts: &'a [A],
+    ) -> Result<Vec<&'a A>, &'static str> {
         // Filter only artifacts we can work with
         if artifacts.is_empty() {
             // If there are no wheel artifacts, we're just gonna skip it
@@ -261,7 +270,7 @@ impl<'db, 'i> PypiDependencyProvider<'db, 'i> {
 
         let mut artifacts = artifacts.iter().collect::<Vec<_>>();
         // Filter yanked artifacts
-        artifacts.retain(|a| !a.yanked.yanked);
+        artifacts.retain(|a| !(*a).borrow().yanked.yanked);
 
         if artifacts.is_empty() {
             return Err("it is yanked");
@@ -271,8 +280,8 @@ impl<'db, 'i> PypiDependencyProvider<'db, 'i> {
         let mut wheels = if self.options.sdist_resolution.allow_wheels() {
             let wheels = artifacts
                 .iter()
-                .filter(|a| a.is::<Wheel>())
-                .cloned()
+                .copied()
+                .filter(|a| (*a).borrow().is::<Wheel>())
                 .collect::<Vec<_>>();
 
             if !self.options.sdist_resolution.allow_sdists() && wheels.is_empty() {
@@ -288,8 +297,10 @@ impl<'db, 'i> PypiDependencyProvider<'db, 'i> {
         let mut sdists = if self.options.sdist_resolution.allow_sdists() {
             let mut sdists = artifacts
                 .iter()
-                .filter(|a| a.is::<SDist>() || a.filename.as_stree().is_some())
-                .cloned()
+                .copied()
+                .filter(|a| {
+                    (*a).borrow().is::<SDist>() || (*a).borrow().filename.as_stree().is_some()
+                })
                 .collect::<Vec<_>>();
 
             if wheels.is_empty() && sdists.is_empty() {
@@ -301,10 +312,11 @@ impl<'db, 'i> PypiDependencyProvider<'db, 'i> {
             }
 
             sdists.retain(|a| {
-                a.filename
+                let ai = (*a).borrow();
+                ai.filename
                     .as_sdist()
                     .is_some_and(|f| f.format.is_supported())
-                    || a.filename.as_stree().is_some()
+                    || ai.filename.as_stree().is_some()
             });
 
             if wheels.is_empty() && sdists.is_empty() {
@@ -318,8 +330,8 @@ impl<'db, 'i> PypiDependencyProvider<'db, 'i> {
 
         // Filter based on compatibility
         if self.options.sdist_resolution.allow_wheels() {
-            if let Some(compatible_tags) = self.compatible_tags {
-                wheels.retain(|artifact| match &artifact.filename {
+            if let Some(compatible_tags) = &self.compatible_tags {
+                wheels.retain(|artifact| match &(*artifact).borrow().filename {
                     ArtifactName::Wheel(wheel_name) => wheel_name
                         .all_tags_iter()
                         .any(|t| compatible_tags.is_compatible(&t)),
@@ -331,7 +343,9 @@ impl<'db, 'i> PypiDependencyProvider<'db, 'i> {
                 // check the most compatible artifacts for dependencies first.
                 // this only needs to be done for wheels
                 wheels.sort_by_cached_key(|a| {
-                    -a.filename
+                    -(*a)
+                        .borrow()
+                        .filename
                         .as_wheel()
                         .expect("only wheels are considered")
                         .all_tags_iter()
@@ -385,9 +399,7 @@ pub(crate) enum MetadataError {
     },
 }
 
-impl<'p> DependencyProvider<PypiVersionSet, PypiPackageName>
-    for &'p PypiDependencyProvider<'_, '_>
-{
+impl<'p> DependencyProvider<PypiVersionSet, PypiPackageName> for &'p PypiDependencyProvider {
     fn pool(&self) -> &Pool<PypiVersionSet, PypiPackageName> {
         &self.pool
     }
@@ -528,7 +540,8 @@ impl<'p> DependencyProvider<PypiVersionSet, PypiPackageName>
             // Determine the candidates
             match self.filter_candidates(artifacts) {
                 Ok(artifacts) => {
-                    self.cached_artifacts.insert(solvable_id, artifacts);
+                    self.cached_artifacts
+                        .insert(solvable_id, artifacts.into_iter().cloned().collect());
                 }
                 Err(reason) => {
                     candidates
@@ -696,7 +709,7 @@ impl<'p> DependencyProvider<PypiVersionSet, PypiPackageName>
         for requirement in metadata.requires_dist {
             // Evaluate environment markers
             if let Some(markers) = requirement.marker.as_ref() {
-                if !markers.evaluate(self.markers, &extras) {
+                if !markers.evaluate(&self.markers, &extras) {
                     continue;
                 }
             }

--- a/crates/rattler_installs_packages/src/resolve/solve.rs
+++ b/crates/rattler_installs_packages/src/resolve/solve.rs
@@ -13,10 +13,11 @@ use std::str::FromStr;
 
 use std::collections::HashSet;
 use std::ops::Deref;
+use std::sync::Arc;
 
 /// Represents a single locked down distribution (python package) after calling [`resolve`].
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct PinnedPackage<'db> {
+pub struct PinnedPackage {
     /// The name of the package
     pub name: NormalizedPackageName,
 
@@ -33,7 +34,7 @@ pub struct PinnedPackage<'db> {
     /// `compatible_tags` have been provided to the solver.
     ///
     /// This list may be empty if the package was locked or favored.
-    pub artifacts: Vec<&'db ArtifactInfo>,
+    pub artifacts: Vec<Arc<ArtifactInfo>>,
 }
 
 /// Defines how to handle sdists during resolution.
@@ -252,16 +253,16 @@ pub struct ResolveOptions {
 /// artifacts are not filtered at all
 // TODO: refactor this into an input type of sorts later
 #[allow(clippy::too_many_arguments)]
-pub async fn resolve<'db>(
-    package_db: &'db PackageDb,
+pub async fn resolve(
+    package_db: Arc<PackageDb>,
     requirements: impl IntoIterator<Item = &Requirement>,
-    env_markers: &MarkerEnvironment,
-    compatible_tags: Option<&WheelTags>,
-    locked_packages: HashMap<NormalizedPackageName, PinnedPackage<'db>>,
-    favored_packages: HashMap<NormalizedPackageName, PinnedPackage<'db>>,
-    options: &ResolveOptions,
+    env_markers: Arc<MarkerEnvironment>,
+    compatible_tags: Option<Arc<WheelTags>>,
+    locked_packages: HashMap<NormalizedPackageName, PinnedPackage>,
+    favored_packages: HashMap<NormalizedPackageName, PinnedPackage>,
+    options: ResolveOptions,
     env_variables: HashMap<String, String>,
-) -> miette::Result<Vec<PinnedPackage<'db>>> {
+) -> miette::Result<Vec<PinnedPackage>> {
     // Construct the pool
     let pool = Pool::new();
 
@@ -340,7 +341,7 @@ pub async fn resolve<'db>(
             };
         }
     };
-    let mut result: HashMap<NormalizedPackageName, PinnedPackage<'_>> = HashMap::new();
+    let mut result: HashMap<NormalizedPackageName, PinnedPackage> = HashMap::new();
     for solvable_id in solvables {
         let pool = solver.pool();
         let solvable = pool.resolve_solvable(solvable_id);
@@ -359,7 +360,7 @@ pub async fn resolve<'db>(
                     .get(&solvable_id)
                     .into_iter()
                     .flatten()
-                    .copied()
+                    .cloned()
                     .collect(),
             });
 


### PR DESCRIPTION
Removes the lifetimes from `WheelBuilder` and `resolve` in favor of some `Arc`s. I assume this will have only a very minimal impact on performance/memory usage but it makes the code a hell of a lot easier to understand. 

The motivation to remove them is for concurrency where I often want to `tokio::spawn` stuff. This requires that the future is `'static` which is often not possible with all the lifetimes we used.

Most likely some lifetimes could be returned in the `resolve` function (which don't bubble through the rest of the code) but we can do that later.

Some of the things I turned into Arcs:

* `PackageDb`: we often want to share this between different tasks and datastructures.
* `WheelTags`: this can amount to a lot of data so I thought it would be worth to wrap in an Arc.
* `MarkerEnvironment`: takes up some memory, probably not worth cloning all over the place.
* `ArtifactInfo`: This one bubbled the `'db` lifetime through to everything. I simply used `Arc<ArtifactInfo>` now.