### PR TITLE
feat: find distributions in arbitrary directory

### DIFF
--- a/crates/rattler_installs_packages/src/python_env/mod.rs
+++ b/crates/rattler_installs_packages/src/python_env/mod.rs
@@ -17,7 +17,10 @@ mod byte_code_compiler;
 pub use tags::{WheelTag, WheelTags};
 
 pub use byte_code_compiler::{ByteCodeCompiler, CompilationError, SpawnCompilerError};
-pub use distribution_finder::{find_distributions_in_venv, Distribution, FindDistributionError};
+pub use distribution_finder::{
+    find_distributions_in_directory, find_distributions_in_venv, Distribution,
+    FindDistributionError,
+};
 pub use env_markers::Pep508EnvMakers;
 pub(crate) use system_python::{system_python_executable, FindPythonError};
 pub use system_python::{ParsePythonInterpreterVersionError, PythonInterpreterVersion};


### PR DESCRIPTION
Adds `find_distributions_in_directory` which allows searching for Python distributions in an arbitrary directory instead of a venv. This allows checking if a directory contains a distributions without having to reason about venvs.