### PR TITLE
refactor: renamed artifact traits, so that it is more clear what the use of each is

### DIFF
--- a/crates/rattler_installs_packages/src/artifacts/mod.rs
+++ b/crates/rattler_installs_packages/src/artifacts/mod.rs
@@ -5,6 +5,6 @@ mod stree;
 /// Module for working with PyPA wheels. Contains the [`Wheel`] type, and related functionality.
 pub mod wheel;
 
-pub use sdist::{SDist, SourceArtifact};
+pub use sdist::SDist;
 pub use stree::STree;
 pub use wheel::Wheel;

--- a/crates/rattler_installs_packages/src/artifacts/sdist.rs
+++ b/crates/rattler_installs_packages/src/artifacts/sdist.rs
@@ -1,7 +1,7 @@
 use crate::resolve::PypiVersion;
 use crate::types::{
-    Artifact, HasArtifactName, NormalizedPackageName, SDistFilename, SDistFormat,
-    SourceArtifactName,
+    ArtifactFromBytes, ArtifactFromSource, HasArtifactName, NormalizedPackageName,
+    ReadPyProjectError, SDistFilename, SDistFormat, SourceArtifactName,
 };
 use crate::types::{WheelCoreMetaDataError, WheelCoreMetadata};
 use crate::utils::ReadAndSeek;
@@ -16,33 +16,6 @@ use std::path::{Path, PathBuf};
 use tar::Archive;
 use zip::ZipArchive;
 
-/// SDist or STree act as a SourceArtifact
-/// so we can use it in methods where we expect sdist
-/// to extract metadata
-pub trait SourceArtifact: Sync {
-    /// get bytes of an artifact
-    /// that will we be used for hashing
-    fn try_get_bytes(&self) -> Result<Vec<u8>, std::io::Error>;
-
-    /// Distribution Name
-    fn distribution_name(&self) -> String;
-
-    /// Version ( URL or Version )
-    fn version(&self) -> PypiVersion;
-
-    /// Source artifact name
-    fn artifact_name(&self) -> SourceArtifactName;
-
-    /// Read the build system info from the pyproject.toml
-    fn read_build_info(&self) -> Result<pyproject_toml::BuildSystem, SDistError>;
-
-    /// extract to a specific location
-    /// for sdist we unpack it
-    /// for stree we move it
-    /// as example this method is used by install_build_files
-    fn extract_to(&self, work_dir: &Path) -> std::io::Result<()>;
-}
-
 /// Represents a source distribution artifact.
 pub struct SDist {
     /// Name of the source distribution
@@ -54,17 +27,14 @@ pub struct SDist {
 
 #[derive(thiserror::Error, Debug)]
 pub enum SDistError {
-    #[error("IO error: {0}")]
-    Io(#[from] std::io::Error),
+    #[error("IO error while reading PKG-INFO: {0}")]
+    PkgInfoIOError(#[source] std::io::Error),
 
     #[error("No PKG-INFO found in archive")]
     NoPkgInfoFound,
 
-    #[error("No pyproject.toml found in archive")]
-    NoPyProjectTomlFound,
-
-    #[error("Could not parse pyproject.toml")]
-    PyProjectTomlParseError(String),
+    #[error(transparent)]
+    PyProjectTomlError(#[from] ReadPyProjectError),
 
     #[error("Could not parse metadata")]
     WheelCoreMetaDataError(#[from] WheelCoreMetaDataError),
@@ -84,7 +54,7 @@ impl SDist {
         let name =
             SDistFilename::from_filename(file_name, normalized_package_name).into_diagnostic()?;
         let bytes = fs::File::open(path).into_diagnostic()?;
-        Self::new(name, Box::new(bytes))
+        Self::from_bytes(name, Box::new(bytes))
     }
 
     /// Find entry in tar archive
@@ -136,7 +106,10 @@ impl SDist {
 
     /// Read .PKG-INFO from the archive
     pub fn read_package_info(&self) -> Result<(Vec<u8>, WheelCoreMetadata), SDistError> {
-        if let Some(bytes) = self.find_entry("PKG-INFO")? {
+        if let Some(bytes) = self
+            .find_entry("PKG-INFO")
+            .map_err(SDistError::PkgInfoIOError)?
+        {
             let metadata = WheelCoreMetadata::try_from(bytes.as_slice())?;
 
             Ok((bytes, metadata))
@@ -171,8 +144,8 @@ impl HasArtifactName for SDist {
     }
 }
 
-impl Artifact for SDist {
-    fn new(name: Self::Name, bytes: Box<dyn ReadAndSeek + Send>) -> miette::Result<Self> {
+impl ArtifactFromBytes for SDist {
+    fn from_bytes(name: Self::Name, bytes: Box<dyn ReadAndSeek + Send>) -> miette::Result<Self> {
         Ok(Self {
             name,
             file: parking_lot::Mutex::new(bytes),
@@ -180,7 +153,15 @@ impl Artifact for SDist {
     }
 }
 
-impl SourceArtifact for SDist {
+impl ArtifactFromSource for SDist {
+    fn try_get_bytes(&self) -> Result<Vec<u8>, std::io::Error> {
+        let mut vec = vec![];
+        let mut inner = self.lock_data();
+        inner.rewind()?;
+        inner.read_to_end(&mut vec)?;
+        Ok(vec)
+    }
+
     fn distribution_name(&self) -> String {
         self.name().distribution.as_source_str().to_owned()
     }
@@ -192,28 +173,20 @@ impl SourceArtifact for SDist {
         }
     }
 
-    fn try_get_bytes(&self) -> Result<Vec<u8>, std::io::Error> {
-        let mut vec = vec![];
-        let mut inner = self.lock_data();
-        inner.rewind()?;
-        inner.read_to_end(&mut vec)?;
-        Ok(vec)
-    }
-
     fn artifact_name(&self) -> SourceArtifactName {
         SourceArtifactName::SDist(self.name().to_owned())
     }
 
-    fn read_build_info(&self) -> Result<pyproject_toml::BuildSystem, SDistError> {
+    fn read_build_info(&self) -> Result<pyproject_toml::BuildSystem, ReadPyProjectError> {
         if let Some(bytes) = self.find_entry("pyproject.toml")? {
             let source = String::from_utf8(bytes).map_err(|e| {
-                SDistError::PyProjectTomlParseError(format!(
+                ReadPyProjectError::PyProjectTomlParseError(format!(
                     "could not parse pyproject.toml (bad encoding): {}",
                     e
                 ))
             })?;
             let project = pyproject_toml::PyProjectToml::new(&source).map_err(|e| {
-                SDistError::PyProjectTomlParseError(format!(
+                ReadPyProjectError::PyProjectTomlParseError(format!(
                     "could not parse pyproject.toml (bad toml): {}",
                     e
                 ))
@@ -222,7 +195,7 @@ impl SourceArtifact for SDist {
                 .build_system
                 .ok_or_else(|| std::io::Error::new(ErrorKind::NotFound, "no build-system found"))?)
         } else {
-            Err(SDistError::NoPyProjectTomlFound)
+            Err(ReadPyProjectError::NoPyProjectTomlFound)
         }
     }
 

--- a/crates/rattler_installs_packages/src/artifacts/sdist.rs
+++ b/crates/rattler_installs_packages/src/artifacts/sdist.rs
@@ -260,13 +260,13 @@ fn generic_archive_reader(
 
 #[cfg(test)]
 mod tests {
-    use crate::artifacts::{SDist, SourceArtifact};
+    use crate::artifacts::SDist;
     use crate::index::{ArtifactRequest, PackageSourcesBuilder};
     use crate::python_env::Pep508EnvMakers;
     use crate::resolve::PypiVersion;
     use crate::resolve::SDistResolution;
-    use crate::types::Extra;
     use crate::types::PackageName;
+    use crate::types::{ArtifactFromSource, Extra};
     use crate::wheel_builder::WheelBuilder;
     use crate::{index::PackageDb, resolve::ResolveOptions};
     use insta::{assert_debug_snapshot, assert_ron_snapshot};

--- a/crates/rattler_installs_packages/src/artifacts/wheel.rs
+++ b/crates/rattler_installs_packages/src/artifacts/wheel.rs
@@ -2,7 +2,7 @@ use crate::python_env::{ByteCodeCompiler, CompilationError};
 use crate::types::{DirectUrlJson, HasArtifactName};
 use crate::{
     python_env::PythonInterpreterVersion,
-    types::Artifact,
+    types::ArtifactFromBytes,
     types::EntryPoint,
     types::Extra,
     types::NormalizedPackageName,
@@ -56,8 +56,8 @@ impl HasArtifactName for Wheel {
     }
 }
 
-impl Artifact for Wheel {
-    fn new(name: Self::Name, bytes: Box<dyn ReadAndSeek + Send>) -> miette::Result<Self> {
+impl ArtifactFromBytes for Wheel {
+    fn from_bytes(name: Self::Name, bytes: Box<dyn ReadAndSeek + Send>) -> miette::Result<Self> {
         Ok(Self {
             name,
             archive: Mutex::new(ZipArchive::new(bytes).into_diagnostic()?),
@@ -78,7 +78,7 @@ impl Wheel {
         let wheel_name =
             WheelFilename::from_filename(file_name, normalized_package_name).into_diagnostic()?;
         let file = fs::File::open(path).into_diagnostic()?;
-        Self::new(wheel_name, Box::new(file))
+        Self::from_bytes(wheel_name, Box::new(file))
     }
 
     /// Create a wheel from URL and content.
@@ -97,7 +97,7 @@ impl Wheel {
         let wheel_filename =
             WheelFilename::from_filename(file_name, normalized_package_name).into_diagnostic()?;
 
-        Self::new(wheel_filename.clone(), Box::new(bytes))
+        Self::from_bytes(wheel_filename.clone(), Box::new(bytes))
     }
 
     /// A wheel file always contains a special directory that contains the metadata of the package.

--- a/crates/rattler_installs_packages/src/index/direct_url/file.rs
+++ b/crates/rattler_installs_packages/src/index/direct_url/file.rs
@@ -2,8 +2,8 @@ use crate::artifacts::{SDist, STree, Wheel};
 use crate::index::package_database::DirectUrlArtifactResponse;
 use crate::resolve::PypiVersion;
 use crate::types::{
-    Artifact, ArtifactHashes, ArtifactInfo, ArtifactName, DistInfoMetadata, HasArtifactName,
-    NormalizedPackageName, PackageName, SDistFilename, SDistFormat, STreeFilename,
+    ArtifactFromBytes, ArtifactHashes, ArtifactInfo, ArtifactName, DistInfoMetadata,
+    HasArtifactName, NormalizedPackageName, PackageName, SDistFilename, SDistFormat, STreeFilename,
     WheelCoreMetadata, Yanked,
 };
 use crate::wheel_builder::{WheelBuildError, WheelBuilder};
@@ -47,7 +47,7 @@ pub(crate) async fn get_sdist_from_file_path(
 
     let file = File::open(path).into_diagnostic()?;
 
-    let dummy_sdist = SDist::new(dummy_sdist_file_name, Box::new(file))?;
+    let dummy_sdist = SDist::from_bytes(dummy_sdist_file_name, Box::new(file))?;
 
     let wheel_metadata = wheel_builder
         .get_sdist_metadata(&dummy_sdist)

--- a/crates/rattler_installs_packages/src/index/direct_url/http.rs
+++ b/crates/rattler_installs_packages/src/index/direct_url/http.rs
@@ -3,8 +3,9 @@ use crate::index::http::Http;
 use crate::index::{parse_hash, CacheMode};
 use crate::resolve::PypiVersion;
 use crate::types::{
-    Artifact, ArtifactHashes, ArtifactInfo, ArtifactName, DistInfoMetadata, HasArtifactName,
-    NormalizedPackageName, PackageName, SDistFilename, SDistFormat, WheelCoreMetadata, Yanked,
+    ArtifactFromBytes, ArtifactHashes, ArtifactInfo, ArtifactName, DistInfoMetadata,
+    HasArtifactName, NormalizedPackageName, PackageName, SDistFilename, SDistFormat,
+    WheelCoreMetadata, Yanked,
 };
 use crate::utils::ReadAndSeek;
 use crate::wheel_builder::WheelBuilder;
@@ -117,7 +118,7 @@ async fn get_sdist_from_bytes(
     // we don't know the version for artifact until we extract the actual metadata
     // so we create a plain sdist object aka dummy
     // and populate it with correct metadata after calling `get_sdist_metadata`
-    let dummy_sdist = SDist::new(dummy_sdist_file_name, Box::new(bytes))?;
+    let dummy_sdist = SDist::from_bytes(dummy_sdist_file_name, Box::new(bytes))?;
 
     let wheel_metadata = wheel_builder
         .get_sdist_metadata(&dummy_sdist)

--- a/crates/rattler_installs_packages/src/index/package_database.rs
+++ b/crates/rattler_installs_packages/src/index/package_database.rs
@@ -9,7 +9,8 @@ use crate::types::{ArtifactInfo, ProjectInfo, WheelCoreMetadata};
 
 use crate::wheel_builder::{WheelBuilder, WheelCache};
 use crate::{
-    types::Artifact, types::InnerAsArtifactName, types::NormalizedPackageName, types::WheelFilename,
+    types::ArtifactFromBytes, types::InnerAsArtifactName, types::NormalizedPackageName,
+    types::WheelFilename,
 };
 use async_http_range_reader::{AsyncHttpRangeReader, CheckSupportMethod};
 use async_recursion::async_recursion;
@@ -555,7 +556,7 @@ impl PackageDb {
 
     /// Opens the specified artifact info. Depending on the specified `cache_mode`, downloads the
     /// artifact data from the remote location if the information is not already cached.
-    async fn get_cached_artifact<A: Artifact>(
+    async fn get_cached_artifact<A: ArtifactFromBytes>(
         &self,
         artifact_info: &ArtifactInfo,
         cache_mode: CacheMode,
@@ -588,7 +589,7 @@ impl PackageDb {
             .into_local()
             .await
             .into_diagnostic()?;
-        A::new(name.clone(), bytes)
+        A::from_bytes(name.clone(), bytes)
     }
 }
 

--- a/crates/rattler_installs_packages/src/resolve/dependency_provider.rs
+++ b/crates/rattler_installs_packages/src/resolve/dependency_provider.rs
@@ -6,7 +6,7 @@ use crate::index::{ArtifactRequest, PackageDb};
 use crate::python_env::WheelTags;
 use crate::resolve::{PinnedPackage, ResolveOptions};
 use crate::types::{
-    Artifact, ArtifactInfo, ArtifactName, Extra, NormalizedPackageName, PackageName,
+    ArtifactFromBytes, ArtifactInfo, ArtifactName, Extra, NormalizedPackageName, PackageName,
 };
 use crate::wheel_builder::WheelBuilder;
 use elsa::FrozenMap;
@@ -377,7 +377,7 @@ impl PypiDependencyProvider {
         Ok(artifacts)
     }
 
-    fn solvable_has_artifact_type<S: Artifact>(&self, solvable_id: SolvableId) -> bool {
+    fn solvable_has_artifact_type<S: ArtifactFromBytes>(&self, solvable_id: SolvableId) -> bool {
         self.cached_artifacts
             .get(&solvable_id)
             .unwrap_or(&[])

--- a/crates/rattler_installs_packages/src/types/artifact.rs
+++ b/crates/rattler_installs_packages/src/types/artifact.rs
@@ -1,5 +1,8 @@
 use super::artifact_name::InnerAsArtifactName;
+use crate::resolve::PypiVersion;
+use crate::types::SourceArtifactName;
 use crate::utils::ReadAndSeek;
+use std::path::Path;
 
 /// Trait to implement if it is a type that has an [`super::artifact_name::ArtifactName`]
 /// this is then used by the [`crate::index::PackageDb`] to make a difference
@@ -17,7 +20,48 @@ pub trait HasArtifactName {
 
 /// Trait that represents an artifact type in the PyPI ecosystem.
 /// That is a single file like a wheel, sdist.
-pub trait Artifact: HasArtifactName + Sized {
+pub trait ArtifactFromBytes: HasArtifactName + Sized {
     /// Construct a new artifact from the given bytes
-    fn new(name: Self::Name, bytes: Box<dyn ReadAndSeek + Send>) -> miette::Result<Self>;
+    fn from_bytes(name: Self::Name, bytes: Box<dyn ReadAndSeek + Send>) -> miette::Result<Self>;
+}
+
+/// Error while reading pyproject.toml
+#[derive(thiserror::Error, Debug)]
+#[allow(missing_docs)]
+pub enum ReadPyProjectError {
+    #[error("IO error while reading pyproject.toml: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("No pyproject.toml found in archive")]
+    NoPyProjectTomlFound,
+
+    #[error("Could not parse pyproject.toml")]
+    PyProjectTomlParseError(String),
+}
+
+/// SDist or STree act as a SourceArtifact
+/// so we can use it in methods where we expect sdist
+/// to extract metadata
+pub trait ArtifactFromSource: HasArtifactName + Sync {
+    /// get bytes of an artifact
+    /// that will we be used for hashing
+    fn try_get_bytes(&self) -> Result<Vec<u8>, std::io::Error>;
+
+    /// Distribution Name
+    fn distribution_name(&self) -> String;
+
+    /// Version ( URL or Version )
+    fn version(&self) -> PypiVersion;
+
+    /// Source artifact name
+    fn artifact_name(&self) -> SourceArtifactName;
+
+    /// Read the build system info from the pyproject.toml
+    fn read_build_info(&self) -> Result<pyproject_toml::BuildSystem, ReadPyProjectError>;
+
+    /// extract to a specific location
+    /// for sdist we unpack it
+    /// for stree we move it
+    /// as example this method is used by install_build_files
+    fn extract_to(&self, work_dir: &Path) -> std::io::Result<()>;
 }

--- a/crates/rattler_installs_packages/src/types/mod.rs
+++ b/crates/rattler_installs_packages/src/types/mod.rs
@@ -19,7 +19,7 @@ mod project_info;
 mod direct_url_json;
 mod rfc822ish;
 
-pub use artifact::{Artifact, HasArtifactName};
+pub use artifact::{ArtifactFromBytes, ArtifactFromSource, HasArtifactName, ReadPyProjectError};
 
 pub use artifact_name::{
     ArtifactName, BuildTag, InnerAsArtifactName, ParseArtifactNameError, SDistFilename,

--- a/crates/rattler_installs_packages/src/wheel_builder/build_environment.rs
+++ b/crates/rattler_installs_packages/src/wheel_builder/build_environment.rs
@@ -1,5 +1,5 @@
 use crate::artifacts::wheel::UnpackWheelOptions;
-use crate::artifacts::SourceArtifact;
+use crate::types::ArtifactFromSource;
 
 use crate::python_env::{PythonLocation, VEnv};
 use crate::resolve::{resolve, PinnedPackage};
@@ -131,7 +131,7 @@ impl BuildEnvironment {
     /// Extract the wheel and write the build_frontend.py to the work folder
     pub(crate) fn install_build_files(
         &mut self,
-        sdist: &(impl SourceArtifact + ?Sized),
+        sdist: &(impl ArtifactFromSource + ?Sized),
     ) -> std::io::Result<()> {
         // Extract the sdist to the work folder
         // extract to a specific package dir
@@ -349,7 +349,7 @@ impl BuildEnvironment {
 
     /// Setup the build environment so that we can build a wheel from an sdist
     pub(crate) async fn setup(
-        sdist: &impl SourceArtifact,
+        sdist: &impl ArtifactFromSource,
         wheel_builder: &WheelBuilder,
     ) -> Result<BuildEnvironment, WheelBuildError> {
         // Setup a work directory and a new env dir

--- a/crates/rattler_installs_packages/src/wheel_builder/mod.rs
+++ b/crates/rattler_installs_packages/src/wheel_builder/mod.rs
@@ -15,9 +15,9 @@ use std::{collections::HashMap, path::PathBuf};
 use parking_lot::Mutex;
 use pep508_rs::MarkerEnvironment;
 
-use crate::artifacts::SourceArtifact;
 use crate::python_env::{ParsePythonInterpreterVersionError, PythonInterpreterVersion};
 use crate::resolve::{OnWheelBuildFailure, ResolveOptions};
+use crate::types::ArtifactFromSource;
 use crate::types::{NormalizedPackageName, PackageName, SourceArtifactName, WheelFilename};
 use crate::wheel_builder::build_environment::BuildEnvironment;
 pub use crate::wheel_builder::wheel_cache::{WheelCache, WheelCacheKey};
@@ -91,7 +91,7 @@ impl WheelBuilder {
     /// This function also caches the virtualenvs, so that they can be reused later.
     async fn setup_build_venv(
         &self,
-        sdist: &impl SourceArtifact,
+        sdist: &impl ArtifactFromSource,
     ) -> Result<Arc<BuildEnvironment>, WheelBuildError> {
         if let Some(venv) = self.venv_cache.lock().get(&sdist.artifact_name()) {
             tracing::debug!(
@@ -158,7 +158,7 @@ impl WheelBuilder {
     /// This function uses the `prepare_metadata_for_build_wheel` entry point of the build backend.
 
     #[tracing::instrument(skip_all, fields(name = %sdist.distribution_name(), version = %sdist.version()))]
-    pub async fn get_sdist_metadata<S: SourceArtifact>(
+    pub async fn get_sdist_metadata<S: ArtifactFromSource>(
         &self,
         sdist: &S,
     ) -> Result<(Vec<u8>, WheelCoreMetadata), WheelBuildError> {
@@ -181,7 +181,7 @@ impl WheelBuilder {
         self.handle_build_failure(result, &build_environment)
     }
 
-    async fn get_sdist_metadata_internal<S: SourceArtifact>(
+    async fn get_sdist_metadata_internal<S: ArtifactFromSource>(
         &self,
         build_environment: &BuildEnvironment,
         sdist: &S,
@@ -212,7 +212,7 @@ impl WheelBuilder {
     /// Build a wheel from an sdist by using the build_backend in a virtual env.
     /// This function uses the `build_wheel` entry point of the build backend.
     #[tracing::instrument(skip_all, fields(name = %sdist.distribution_name(), version = %sdist.version()))]
-    pub async fn build_wheel<S: SourceArtifact>(
+    pub async fn build_wheel<S: ArtifactFromSource>(
         &self,
         sdist: &S,
     ) -> Result<Wheel, WheelBuildError> {
@@ -231,7 +231,7 @@ impl WheelBuilder {
         self.handle_build_failure(result, &build_environment)
     }
 
-    async fn build_wheel_internal<S: SourceArtifact>(
+    async fn build_wheel_internal<S: ArtifactFromSource>(
         &self,
         build_environment: &BuildEnvironment,
         sdist: &S,

--- a/crates/rattler_installs_packages/src/wheel_builder/wheel_cache.rs
+++ b/crates/rattler_installs_packages/src/wheel_builder/wheel_cache.rs
@@ -26,10 +26,10 @@
 //!
 //! So cacache stores the hashed wheel key and associated with this is with the content hash of the wheel
 //! This way multiple WheelCacheKeys can point to the same wheel.
-
-use crate::artifacts::{SourceArtifact, Wheel};
+use crate::artifacts::Wheel;
 use crate::python_env::PythonInterpreterVersion;
-use crate::types::{Artifact, WheelFilename};
+use crate::types::ArtifactFromSource;
+use crate::types::{ArtifactFromBytes, WheelFilename};
 use cacache::{Integrity, WriteOpts};
 use rattler_digest::Sha256;
 use serde::{Deserialize, Serialize};
@@ -77,7 +77,7 @@ impl WheelCacheKey {
 
     /// Create a WheelCacheKey from an sdist and the python interpreter version
     pub fn from_sdist(
-        sdist: &impl SourceArtifact,
+        sdist: &impl ArtifactFromSource,
         python_interpreter_version: &PythonInterpreterVersion,
     ) -> Result<WheelCacheKey, std::io::Error> {
         let hash = sdist.try_get_bytes()?;
@@ -173,7 +173,7 @@ impl WheelCache {
 
             // Find wheel associated with integrity
             let bytes = Cursor::new(cacache::read_hash_sync(&self.path, &integrity)?);
-            let wheel = Wheel::new(value.wheel_filename, Box::new(bytes));
+            let wheel = Wheel::from_bytes(value.wheel_filename, Box::new(bytes));
 
             // Need to do this to get out of miette::Result
             // TODO: change artifact to not use miette::Result?


### PR DESCRIPTION
Renamed trait to:

* `ArtifactFromBytes` represent an artifact that can be constructed from bytes
* `ArtifactFromSource` represents an artifiact that can be built from source.

Also moved the traits together.