### PR TITLE
fix: only write out amount of bytes read

### DIFF
--- a/crates/rattler_installs_packages/src/utils/streaming_or_local.rs
+++ b/crates/rattler_installs_packages/src/utils/streaming_or_local.rs
@@ -40,7 +40,7 @@ impl StreamingOrLocal {
                     if bytes_read == 0 {
                         break;
                     }
-                    local_file.write_all(&buf)?;
+                    local_file.write_all(&buf[..bytes_read])?;
                 }
 
                 // Restart the file from the start so we can start reading from it.


### PR DESCRIPTION
Fixes a bug when pulling sdists where data from a previous chunk will be written to the end of the final chunk, causing gzip to throw errors.