### PR TITLE
fix: limits the amount of concurrent tasks with the new async resolvo code

### DIFF
--- a/crates/rattler_installs_packages/src/index/http.rs
+++ b/crates/rattler_installs_packages/src/index/http.rs
@@ -254,6 +254,7 @@ where
 {
     let data: CacheData = ciborium::de::from_reader(&mut f)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+
     let start = f.stream_position()?;
     let end = f.seek(SeekFrom::End(0))?;
     let mut body = SeekSlice::new(f, start, end)?;


### PR DESCRIPTION
Otherwise, `apache-airflow[all]` would just start failing randomly. Because of too many open files and other dns errors. This fixes that problem. I don't know if 30 is a good default but seems to work for me 👼 