### PR TITLE
feat: adds the ability to use the server age while requesting available artifacts

### DIFF
--- a/crates/rattler_installs_packages/src/index/mod.rs
+++ b/crates/rattler_installs_packages/src/index/mod.rs
@@ -9,7 +9,7 @@ mod http;
 mod package_database;
 mod package_sources;
 
-pub use package_database::{ArtifactRequest, PackageDb};
+pub use package_database::{ArtifactRequest, CheckAvailablePackages, PackageDb};
 pub use package_sources::{PackageSources, PackageSourcesBuilder};
 
 pub use self::http::CacheMode;

--- a/crates/rattler_installs_packages/src/utils/test.rs
+++ b/crates/rattler_installs_packages/src/utils/test.rs
@@ -19,7 +19,7 @@ pub fn get_package_db() -> (Arc<PackageDb>, TempDir) {
     let sources = PackageSourcesBuilder::new(url).build().unwrap();
 
     (
-        Arc::new(PackageDb::new(sources, client, tempdir.path()).unwrap()),
+        Arc::new(PackageDb::new(sources, client, tempdir.path(), Default::default()).unwrap()),
         tempdir,
     )
 }

--- a/crates/rattler_installs_packages/src/wheel_builder/mod.rs
+++ b/crates/rattler_installs_packages/src/wheel_builder/mod.rs
@@ -396,7 +396,7 @@ mod tests {
         let sources = PackageSourcesBuilder::new(url).build().unwrap();
 
         (
-            Arc::new(PackageDb::new(sources, client, tempdir.path()).unwrap()),
+            Arc::new(PackageDb::new(sources, client, tempdir.path(), Default::default()).unwrap()),
             tempdir,
         )
     }


### PR DESCRIPTION
Adds an option to the `PackageDb` to trust the server age for requests regarding `available_artifacts`. This saves us from doing a bunch of requests. Also adds `--use-server-timout` to binary for testing this.