### PR TITLE
refactor: use which to find the correct python executable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,6 +1201,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "html-escape"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,6 +2329,7 @@ dependencies = [
  "tracing",
  "tracing-test",
  "url",
+ "which",
  "zip",
 ]
 
@@ -3667,6 +3677,19 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "which"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fa5e0c10bf77f44aac573e498d1a82d5fbd5e91f6fc0a99e7be4b38e85e101c"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "winapi"

--- a/crates/rattler_installs_packages/Cargo.toml
+++ b/crates/rattler_installs_packages/Cargo.toml
@@ -71,6 +71,7 @@ async-recursion = "1.0.5"
 fs-err = "2.11.0"
 fs_extra = "1.3.0"
 async_http_range_reader = "0.6.0"
+which = "6.0.0"
 
 [dev-dependencies]
 anyhow = "1.0.79"


### PR DESCRIPTION
On windows, when python was installed using `pixi`, rip was not able to find the python executable because the extension was `.bat`. This PR reintroduces `which` to find the initial python binary to invoke, following by the existing code to determine python binary using python itself.