### PR TITLE
fix: don't strip auth from url

### DIFF
--- a/crates/rattler_installs_packages/src/index/package_database.rs
+++ b/crates/rattler_installs_packages/src/index/package_database.rs
@@ -754,8 +754,6 @@ async fn fetch_simple_api(http: &Http, url: Url) -> miette::Result<Option<Projec
         .unwrap_or("text/html")
         .to_owned();
 
-    let url = response.extensions().get::<Url>().unwrap().to_owned();
-
     // Convert the information from html
     let mut bytes = Vec::new();
     response


### PR DESCRIPTION
Getting the URL from the response extensions instead of simply using the input URL strips authentication data from the URL.  Doing this not only prevents downloading artifacts from a private registry using basic auth, but also causes caching errors when removing a given lock because of the way cache keys are calculated.