### PR TITLE
Add feature to work when `configparser` enables `indexmap`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,6 +575,9 @@ name = "configparser"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec6d3da8e550377a85339063af6e3735f4b1d9392108da4e083a1b3b9820288"
+dependencies = [
+ "indexmap 2.2.6",
+]
 
 [[package]]
 name = "console"

--- a/crates/rattler_installs_packages/Cargo.toml
+++ b/crates/rattler_installs_packages/Cargo.toml
@@ -16,6 +16,7 @@ include = ["src/", "vendor/", "benches/"]
 default = ["native-tls"]
 native-tls = ['reqwest/native-tls']
 rustls-tls = ['reqwest/rustls-tls']
+configparser-indexmap = ["configparser/indexmap"]
 
 [dependencies]
 async-trait = "0.1.80"


### PR DESCRIPTION
Add a feature which allows building against a `configparser` dep
that has it's `indexmap` featured enabled, which return `IndexMap`
sections instead of `HashMap`.